### PR TITLE
Add Authentication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_install:
     - sudo influxd > $HOME/influx.log 2>&1 &
     - sed -e 's/# auth-enabled = false/auth-enabled = true/' -e 's/# bind-address = ".*:8086"/bind-address = "127.0.0.1:9086"/' -e 's/dir = "\/var\/lib\/influxdb\/meta"/dir = "\/var\/lib\/influxdb\/meta2"/' -e 's/dir = "\/var\/lib\/influxdb\/data"/dir = "\/var\/lib\/influxdb\/data2"/' -e 's/dir = "\/var\/lib\/influxdb\/wal"/dir = "\/var\/lib\/influxdb\/wal2"/' /etc/influxdb/influxdb.conf > $HOME/influxdb_authed.conf
     - sudo influxd -config $HOME/influxdb_authed.conf> $HOME/influx_authed.log 2>&1 &
+    - until curl -s -o /dev/null 'http://localhost:9086' 2>/dev/null; do sleep 1; done
     - influx -port '9086' -execute "CREATE USER admin WITH PASSWORD 'password' WITH ALL PRIVILEGES; CREATE USER nopriv_user WITH PASSWORD 'password';"
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ before_install:
     - wget https://dl.influxdata.com/influxdb/releases/influxdb_1.7.6_amd64.deb
     - sudo dpkg -i influxdb_1.7.6_amd64.deb
     - sudo influxd > $HOME/influx.log 2>&1 &
-    - sed -e 's/# auth-enabled = false/auth-enabled = true/' -e 's/# bind-address = ".*:8086"/bind-address = "127.0.0.1:9086"/' /etc/influxdb/influxdb.conf > $HOME/influxdb_authed.conf
+    - sed -e 's/# auth-enabled = false/auth-enabled = true/' -e 's/# bind-address = ".*:8086"/bind-address = "127.0.0.1:9086"/' -e 's/dir = "\/var\/lib\/influxdb\/meta"/dir = "\/var\/lib\/influxdb\/meta2"/' -e 's/dir = "\/var\/lib\/influxdb\/data"/dir = "\/var\/lib\/influxdb\/data2"/' -e 's/dir = "\/var\/lib\/influxdb\/wal"/dir = "\/var\/lib\/influxdb\/wal2"/' /etc/influxdb/influxdb.conf > $HOME/influxdb_authed.conf
     - sudo influxd -config $HOME/influxdb_authed.conf> $HOME/influx_authed.log 2>&1 &
-    - influx -port '9086' -execute "CREATE USER user WITH PASSWORD 'password' WITH ALL PRIVILEGES"
+    - influx -port '9086' -execute "CREATE USER admin WITH PASSWORD 'password' WITH ALL PRIVILEGES; CREATE USER nopriv_user WITH PASSWORD 'password';"
 
 branches:
     only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - sudo influxd > $HOME/influx.log 2>&1 &
     - sed -e 's/# auth-enabled = false/auth-enabled = true/' -e 's/# bind-address = ".*:8086"/bind-address = "127.0.0.1:9086"/' /etc/influxdb/influxdb.conf > $HOME/influxdb_authed.conf
     - sudo influxd -config $HOME/influxdb_authed.conf> $HOME/influx_authed.log 2>&1 &
-    - influx -port '9086' -execute 'CREATE USER user WITH PASSWORD \'password\' WITH ALL PRIVILEGES'
+    - influx -port '9086' -execute "CREATE USER user WITH PASSWORD 'password' WITH ALL PRIVILEGES"
 
 branches:
     only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ before_install:
     - wget https://dl.influxdata.com/influxdb/releases/influxdb_1.7.6_amd64.deb
     - sudo dpkg -i influxdb_1.7.6_amd64.deb
     - sudo influxd > $HOME/influx.log 2>&1 &
+    - sed -e 's/# auth-enabled = false/auth-enabled = true/' -e 's/# bind-address = ".*:8086"/bind-address = "127.0.0.1:9086"/' /etc/influxdb/influxdb.conf > $HOME/influxdb_authed.conf
+    - sudo influxd -config $HOME/influxdb_authed.conf> $HOME/influx_authed.log 2>&1 &
+    - influx -port '9086' -execute 'CREATE USER user WITH PASSWORD \'password\' WITH ALL PRIVILEGES'
 
 branches:
     only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,14 @@ language: rust
 
 sudo: required
 
+services:
+    - docker
+
 before_install:
-    - wget https://dl.influxdata.com/influxdb/releases/influxdb_1.7.6_amd64.deb
-    - sudo dpkg -i influxdb_1.7.6_amd64.deb
-    - sudo influxd > $HOME/influx.log 2>&1 &
-    - sed -e 's/# auth-enabled = false/auth-enabled = true/' -e 's/# bind-address = ".*:8086"/bind-address = "127.0.0.1:9086"/' -e 's/dir = "\/var\/lib\/influxdb\/meta"/dir = "\/var\/lib\/influxdb\/meta2"/' -e 's/dir = "\/var\/lib\/influxdb\/data"/dir = "\/var\/lib\/influxdb\/data2"/' -e 's/dir = "\/var\/lib\/influxdb\/wal"/dir = "\/var\/lib\/influxdb\/wal2"/' /etc/influxdb/influxdb.conf > $HOME/influxdb_authed.conf
-    - sudo influxd -config $HOME/influxdb_authed.conf> $HOME/influx_authed.log 2>&1 &
-    - until curl -s -o /dev/null 'http://localhost:9086' 2>/dev/null; do sleep 1; done
-    - influx -port '9086' -execute "CREATE USER admin WITH PASSWORD 'password' WITH ALL PRIVILEGES; CREATE USER nopriv_user WITH PASSWORD 'password';"
+    - docker pull influxdb
+    - docker run -d -p 8086:8086 --name influxdb influxdb
+    - docker run -d -p 9086:8086 --name authed_influxdb -e INFLUXDB_HTTP_AUTH_ENABLED=true -e INFLUXDB_ADMIN_USER=admin -e INFLUXDB_ADMIN_PASSWORD=password -e INFLUXDB_USER=nopriv_user -e INFLUXDB_USER_PASSWORD=password influxdb
+    - docker ps
 
 branches:
     only:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "influxdb"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,7 +415,6 @@ dependencies = [
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "influxdb"
-version = "0.0.3"
+version = "0.0.4"
 authors = ["Gero Gerke <11deutron11@gmail.com>"]
 edition = "2018"
 description = "InfluxDB Driver for Rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ futures = "0.1.27"
 tokio = "0.1.20"
 itertools = "0.8"
 failure = "0.1.5"
-url = "1.7.2"
 serde = { version = "1.0.92", optional = true }
 serde_json = { version = "1.0", optional = true }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -55,6 +55,18 @@ impl Into<Vec<(String, String)>> for InfluxDbClient {
     }
 }
 
+impl<'a> Into<Vec<(String, String)>> for &'a InfluxDbClient {
+    fn into(self) -> Vec<(String, String)> {
+        let mut vec: Vec<(String, String)> = Vec::new();
+        vec.push(("db".to_string(), self.database.to_owned()));
+        if let Some(auth) = &self.auth {
+            vec.push(("u".to_string(), auth.username.to_owned()));
+            vec.push(("p".to_string(), auth.password.to_owned()));
+        }
+        vec
+    }
+}
+
 impl InfluxDbClient {
     /// Instantiates a new [`InfluxDbClient`](crate::client::InfluxDbClient)
     ///
@@ -189,7 +201,7 @@ impl InfluxDbClient {
         };
 
         let any_value = q as &dyn Any;
-        let basic_parameters: Vec<(String, String)> = (self.clone()).into();
+        let basic_parameters: Vec<(String, String)> = self.into();
 
         let client = if let Some(_) = any_value.downcast_ref::<InfluxDbReadQuery>() {
             let read_query = query.get();

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -251,12 +251,8 @@ impl InfluxDbClient {
                 .and_then(
                     |res| -> future::FutureResult<reqwest::r#async::Response, InfluxDbError> {
                         match res.status() {
-                            StatusCode::UNAUTHORIZED => {
-                                futures::future::err(InfluxDbError::AuthorizationError)
-                            }
-                            StatusCode::FORBIDDEN => {
-                                futures::future::err(InfluxDbError::AuthenticationError)
-                            }
+                            StatusCode::UNAUTHORIZED => futures::future::err(InfluxDbError::AuthorizationError),
+                            StatusCode::FORBIDDEN => futures::future::err(InfluxDbError::AuthenticationError),
                             _ => futures::future::ok(res),
                         }
                     },
@@ -293,6 +289,12 @@ impl InfluxDbClient {
 mod tests {
     use crate::client::InfluxDbClient;
 
+    #[test]
+    fn test_fn_database() {
+        let client = InfluxDbClient::new("http://localhost:8068", "database");
+        assert_eq!("database", client.database_name());
+    }
+    
     #[test]
     fn test_with_auth() {
         let client = InfluxDbClient::new("http://localhost:8068", "database");

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -288,3 +288,64 @@ impl InfluxDbClient {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::client::InfluxDbClient;
+
+    #[test]
+    fn test_with_auth() {
+        let client = InfluxDbClient::new("http://localhost:8068", "database");
+        assert_eq!(client.url, "http://localhost:8068");
+        assert_eq!(client.database, "database");
+        assert!(client.auth.is_none());
+        let with_auth = client.with_auth("username", "password");
+        assert!(with_auth.auth.is_some());
+        let auth = with_auth.auth.unwrap();
+        assert_eq!(&auth.username, "username");
+        assert_eq!(&auth.password, "password");
+    }
+
+    #[test]
+    fn test_into_impl() {
+        let client = InfluxDbClient::new("http://localhost:8068", "database");
+        assert!(client.auth.is_none());
+        let basic_parameters: Vec<(String, String)> = client.into();
+        assert_eq!(
+            vec![("db".to_string(), "database".to_string())],
+            basic_parameters
+        );
+
+        let with_auth = InfluxDbClient::new("http://localhost:8068", "database")
+            .with_auth("username", "password");
+        let basic_parameters_with_auth: Vec<(String, String)> = with_auth.into();
+        assert_eq!(
+            vec![
+                ("db".to_string(), "database".to_string()),
+                ("u".to_string(), "username".to_string()),
+                ("p".to_string(), "password".to_string())
+            ],
+            basic_parameters_with_auth
+        );
+
+        let client = InfluxDbClient::new("http://localhost:8068", "database");
+        assert!(client.auth.is_none());
+        let basic_parameters: Vec<(String, String)> = (&client).into();
+        assert_eq!(
+            vec![("db".to_string(), "database".to_string())],
+            basic_parameters
+        );
+
+        let with_auth = InfluxDbClient::new("http://localhost:8068", "database")
+            .with_auth("username", "password");
+        let basic_parameters_with_auth: Vec<(String, String)> = (&with_auth).into();
+        assert_eq!(
+            vec![
+                ("db".to_string(), "database".to_string()),
+                ("u".to_string(), "username".to_string()),
+                ("p".to_string(), "password".to_string())
+            ],
+            basic_parameters_with_auth
+        );
+    }
+}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -242,7 +242,6 @@ impl InfluxDbClient {
                         _ => {futures::future::ok(res)}
                     }
                 })
-                // .inspect(|&x| println!("about to resolve: {:?}", x))
                 .and_then(|mut res| {
                     let body = mem::replace(res.body_mut(), Decoder::empty());
                     body.concat2()

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -251,8 +251,12 @@ impl InfluxDbClient {
                 .and_then(
                     |res| -> future::FutureResult<reqwest::r#async::Response, InfluxDbError> {
                         match res.status() {
-                            StatusCode::UNAUTHORIZED => futures::future::err(InfluxDbError::AuthorizationError),
-                            StatusCode::FORBIDDEN => futures::future::err(InfluxDbError::AuthenticationError),
+                            StatusCode::UNAUTHORIZED => {
+                                futures::future::err(InfluxDbError::AuthorizationError)
+                            }
+                            StatusCode::FORBIDDEN => {
+                                futures::future::err(InfluxDbError::AuthenticationError)
+                            }
                             _ => futures::future::ok(res),
                         }
                     },
@@ -294,7 +298,7 @@ mod tests {
         let client = InfluxDbClient::new("http://localhost:8068", "database");
         assert_eq!("database", client.database_name());
     }
-    
+
     #[test]
     fn test_with_auth() {
         let client = InfluxDbClient::new("http://localhost:8068", "database");

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -95,8 +95,7 @@ impl InfluxDbClient {
     /// ```rust
     /// use influxdb::client::InfluxDbClient;
     ///
-    /// let client = InfluxDbClient::new("http://localhost:8086", "test");
-    /// let _authed_client =  client.with_auth("admin", "password123")
+    /// let _client = InfluxDbClient::new("http://localhost:9086", "test").with_auth("admin", "password");
     /// ```
     pub fn with_auth<'a, S1, S2>(mut self, username: S1, password: S2) -> Self
     where

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,6 +34,7 @@ pub enum InfluxDbError {
     #[fail(display = "connection error: {}", error)]
     /// Error happens when reqwest fails
     ConnectionError {
-        #[fail(cause)] error: reqwest::Error,
+        #[fail(cause)]
+        error: reqwest::Error,
     },
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,15 @@
 //! Errors that might happen in the crate
+use reqwest;
 
 #[derive(Debug, Fail)]
 pub enum InfluxDbError {
     #[fail(display = "query is invalid: {}", error)]
     /// Error happens when a query is invalid
     InvalidQueryError { error: String },
+
+    #[fail(display = "Failed to build URL: {}", error)]
+    /// Error happens when a query is invalid
+    UrlConstructionError { error: String },
 
     #[fail(display = "http protocol error: {}", error)]
     /// Error happens when a query is invalid
@@ -17,4 +22,18 @@ pub enum InfluxDbError {
     #[fail(display = "InfluxDB encountered the following error: {}", error)]
     /// Error which has happened inside InfluxDB
     DatabaseError { error: String },
+
+    #[fail(display = "authentication error. No or incorrect credentials")]
+    /// Error happens when no or incorrect credentials are used. `HTTP 401 Unauthorized`
+    AuthenticationError,
+
+    #[fail(display = "authorization error. User not authorized")]
+    /// Error happens when the supplied user is not authorized. `HTTP 403 Forbidden`
+    AuthorizationError,
+
+    #[fail(display = "connection error: {}", error)]
+    /// Error happens when reqwest fails
+    ConnectionError {
+        #[fail(cause)] error: reqwest::Error,
+    },
 }

--- a/src/integrations/serde_integration.rs
+++ b/src/integrations/serde_integration.rs
@@ -117,7 +117,7 @@ impl InfluxDbClient {
         use futures::future;
 
         let query = q.build().unwrap();
-        let basic_parameters: Vec<(String, String)> = self.clone().into();
+        let basic_parameters: Vec<(String, String)> = self.into();
         let client = {
             let read_query = query.get();
 

--- a/src/query/write_query.rs
+++ b/src/query/write_query.rs
@@ -72,7 +72,7 @@ impl InfluxDbWriteQuery {
         self
     }
 
-    pub fn get_precision_modifier(&self) -> String {
+    pub fn get_precision(&self) -> String {
         let modifier = match self.timestamp {
             Timestamp::NOW => return String::from(""),
             Timestamp::NANOSECONDS(_) => "ns",
@@ -83,7 +83,6 @@ impl InfluxDbWriteQuery {
             Timestamp::HOURS(_) => "h",
         };
         modifier.to_string()
-        // format!("&precision={modifier}", modifier = modifier)
     }
 }
 

--- a/src/query/write_query.rs
+++ b/src/query/write_query.rs
@@ -82,8 +82,8 @@ impl InfluxDbWriteQuery {
             Timestamp::MINUTES(_) => "m",
             Timestamp::HOURS(_) => "h",
         };
-
-        format!("&precision={modifier}", modifier = modifier)
+        modifier.to_string()
+        // format!("&precision={modifier}", modifier = modifier)
     }
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -279,7 +279,6 @@ fn test_non_authed_write_and_read() {
     }
 }
 
-
 #[test]
 /// INTEGRATION TEST
 ///

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -195,6 +195,32 @@ fn test_wrong_authed_write_and_read() {
 #[test]
 /// INTEGRATION TEST
 ///
+/// This test case tests connection error
+fn test_connection_error() {
+    let test_name = "test_connection_error";
+    let client = InfluxDbClient::new("http://localhost:10086", test_name)
+        .with_auth("nopriv_user", "password");
+    let read_query = InfluxDbQuery::raw_read_query("SELECT * FROM weather");
+    let read_result = get_runtime().block_on(client.query(&read_query));
+    assert!(
+        read_result.is_err(),
+        format!("Should be an error: {}", read_result.unwrap_err())
+    );
+    match read_result {
+        Err(InfluxDbError::ConnectionError{..}) => assert!(true),
+        _ => assert!(
+            false,
+            format!(
+                "Should cause a ConnectionError: {}",
+                read_result.unwrap_err()
+            )
+        ),
+    }
+}
+
+#[test]
+/// INTEGRATION TEST
+///
 /// This test case tests the Authentication
 fn test_non_authed_write_and_read() {
     let test_name = "test_non_authed_write_and_read";

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -50,7 +50,11 @@ where
 fn test_ping_influx_db() {
     let client = create_client("notusedhere");
     let result = get_runtime().block_on(client.ping());
-    assert!(result.is_ok(), "Should be no error: {}", result.unwrap_err());
+    assert!(
+        result.is_ok(),
+        "Should be no error: {}",
+        result.unwrap_err()
+    );
 
     let (build, version) = result.unwrap();
     assert!(!build.is_empty(), "Build should not be empty");
@@ -65,21 +69,27 @@ fn test_ping_influx_db() {
 /// This test case tests the Authentication
 fn test_authed_write_and_read() {
     let test_name = "test_authed_write_and_read";
-    let client = InfluxDbClient::new("http://localhost:9086", test_name).with_auth("admin", "password");
+    let client =
+        InfluxDbClient::new("http://localhost:9086", test_name).with_auth("admin", "password");
     let query = format!("CREATE DATABASE {}", test_name);
-    get_runtime().block_on(client.query(&InfluxDbQuery::raw_read_query(query))).expect("could not setup db");
+    get_runtime()
+        .block_on(client.query(&InfluxDbQuery::raw_read_query(query)))
+        .expect("could not setup db");
 
     let _run_on_drop = RunOnDrop {
         closure: Box::new(|| {
             let test_name = "test_authed_write_and_read";
-            let client = InfluxDbClient::new("http://localhost:9086", test_name).with_auth("admin", "password");
+            let client = InfluxDbClient::new("http://localhost:9086", test_name)
+                .with_auth("admin", "password");
             let query = format!("DROP DATABASE {}", test_name);
-            get_runtime().block_on(client.query(&InfluxDbQuery::raw_read_query(query))).expect("could not clean up db");
+            get_runtime()
+                .block_on(client.query(&InfluxDbQuery::raw_read_query(query)))
+                .expect("could not clean up db");
         }),
     };
 
-
-    let client = InfluxDbClient::new("http://localhost:9086", test_name).with_auth("admin", "password");
+    let client =
+        InfluxDbClient::new("http://localhost:9086", test_name).with_auth("admin", "password");
     let write_query =
         InfluxDbQuery::write_query(Timestamp::HOURS(11), "weather").add_field("temperature", 82);
     let write_result = get_runtime().block_on(client.query(&write_query));
@@ -106,21 +116,27 @@ fn test_authed_write_and_read() {
 /// This test case tests the Authentication
 fn test_wrong_authed_write_and_read() {
     let test_name = "test_wrong_authed_write_and_read";
-    let client = InfluxDbClient::new("http://localhost:9086", test_name).with_auth("admin", "password");
+    let client =
+        InfluxDbClient::new("http://localhost:9086", test_name).with_auth("admin", "password");
     let query = format!("CREATE DATABASE {}", test_name);
-    get_runtime().block_on(client.query(&InfluxDbQuery::raw_read_query(query))).expect("could not setup db");
+    get_runtime()
+        .block_on(client.query(&InfluxDbQuery::raw_read_query(query)))
+        .expect("could not setup db");
 
     let _run_on_drop = RunOnDrop {
         closure: Box::new(|| {
             let test_name = "test_wrong_authed_write_and_read";
-            let client = InfluxDbClient::new("http://localhost:9086", test_name).with_auth("admin", "password");
+            let client = InfluxDbClient::new("http://localhost:9086", test_name)
+                .with_auth("admin", "password");
             let query = format!("DROP DATABASE {}", test_name);
-            get_runtime().block_on(client.query(&InfluxDbQuery::raw_read_query(query))).expect("could not clean up db");
+            get_runtime()
+                .block_on(client.query(&InfluxDbQuery::raw_read_query(query)))
+                .expect("could not clean up db");
         }),
     };
 
-
-    let client = InfluxDbClient::new("http://localhost:9086", test_name).with_auth("wrong_user", "password");
+    let client =
+        InfluxDbClient::new("http://localhost:9086", test_name).with_auth("wrong_user", "password");
     let write_query =
         InfluxDbQuery::write_query(Timestamp::HOURS(11), "weather").add_field("temperature", 82);
     let write_result = get_runtime().block_on(client.query(&write_query));
@@ -132,10 +148,12 @@ fn test_wrong_authed_write_and_read() {
         Err(InfluxDbError::AuthorizationError) => assert!(true),
         _ => assert!(
             false,
-            format!("Should be an AuthorizationError: {}", write_result.unwrap_err())
-        )
+            format!(
+                "Should be an AuthorizationError: {}",
+                write_result.unwrap_err()
+            )
+        ),
     }
-    
 
     let read_query = InfluxDbQuery::raw_read_query("SELECT * FROM weather");
     let read_result = get_runtime().block_on(client.query(&read_query));
@@ -147,11 +165,15 @@ fn test_wrong_authed_write_and_read() {
         Err(InfluxDbError::AuthorizationError) => assert!(true),
         _ => assert!(
             false,
-            format!("Should be an AuthorizationError: {}", read_result.unwrap_err())
-        )
+            format!(
+                "Should be an AuthorizationError: {}",
+                read_result.unwrap_err()
+            )
+        ),
     }
 
-    let client = InfluxDbClient::new("http://localhost:9086", test_name).with_auth("nopriv_user", "password");
+    let client = InfluxDbClient::new("http://localhost:9086", test_name)
+        .with_auth("nopriv_user", "password");
     let read_query = InfluxDbQuery::raw_read_query("SELECT * FROM weather");
     let read_result = get_runtime().block_on(client.query(&read_query));
     assert!(
@@ -162,8 +184,11 @@ fn test_wrong_authed_write_and_read() {
         Err(InfluxDbError::AuthenticationError) => assert!(true),
         _ => assert!(
             false,
-            format!("Should be an AuthenticationError: {}", read_result.unwrap_err())
-        )
+            format!(
+                "Should be an AuthenticationError: {}",
+                read_result.unwrap_err()
+            )
+        ),
     }
 }
 
@@ -173,16 +198,22 @@ fn test_wrong_authed_write_and_read() {
 /// This test case tests the Authentication
 fn test_non_authed_write_and_read() {
     let test_name = "test_non_authed_write_and_read";
-    let client = InfluxDbClient::new("http://localhost:9086", test_name).with_auth("admin", "password");
+    let client =
+        InfluxDbClient::new("http://localhost:9086", test_name).with_auth("admin", "password");
     let query = format!("CREATE DATABASE {}", test_name);
-    get_runtime().block_on(client.query(&InfluxDbQuery::raw_read_query(query))).expect("could not setup db");
+    get_runtime()
+        .block_on(client.query(&InfluxDbQuery::raw_read_query(query)))
+        .expect("could not setup db");
 
     let _run_on_drop = RunOnDrop {
         closure: Box::new(|| {
             let test_name = "test_non_authed_write_and_read";
-            let client = InfluxDbClient::new("http://localhost:9086", test_name).with_auth("admin", "password");
+            let client = InfluxDbClient::new("http://localhost:9086", test_name)
+                .with_auth("admin", "password");
             let query = format!("DROP DATABASE {}", test_name);
-            get_runtime().block_on(client.query(&InfluxDbQuery::raw_read_query(query))).expect("could not clean up db");
+            get_runtime()
+                .block_on(client.query(&InfluxDbQuery::raw_read_query(query)))
+                .expect("could not clean up db");
         }),
     };
     let non_authed_client = InfluxDbClient::new("http://localhost:9086", test_name);
@@ -197,8 +228,11 @@ fn test_non_authed_write_and_read() {
         Err(InfluxDbError::AuthorizationError) => assert!(true),
         _ => assert!(
             false,
-            format!("Should be an AuthorizationError: {}", write_result.unwrap_err())
-        )
+            format!(
+                "Should be an AuthorizationError: {}",
+                write_result.unwrap_err()
+            )
+        ),
     }
 
     let read_query = InfluxDbQuery::raw_read_query("SELECT * FROM weather");
@@ -211,8 +245,11 @@ fn test_non_authed_write_and_read() {
         Err(InfluxDbError::AuthorizationError) => assert!(true),
         _ => assert!(
             false,
-            format!("Should be an AuthorizationError: {}", read_result.unwrap_err())
-        )
+            format!(
+                "Should be an AuthorizationError: {}",
+                read_result.unwrap_err()
+            )
+        ),
     }
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -66,6 +66,32 @@ fn test_ping_influx_db() {
 #[test]
 /// INTEGRATION TEST
 ///
+/// This test case tests connection error
+fn test_connection_error() {
+    let test_name = "test_connection_error";
+    let client = InfluxDbClient::new("http://localhost:10086", test_name)
+        .with_auth("nopriv_user", "password");
+    let read_query = InfluxDbQuery::raw_read_query("SELECT * FROM weather");
+    let read_result = get_runtime().block_on(client.query(&read_query));
+    assert!(
+        read_result.is_err(),
+        format!("Should be an error: {}", read_result.unwrap_err())
+    );
+    match read_result {
+        Err(InfluxDbError::ConnectionError { .. }) => assert!(true),
+        _ => assert!(
+            false,
+            format!(
+                "Should cause a ConnectionError: {}",
+                read_result.unwrap_err()
+            )
+        ),
+    }
+}
+
+#[test]
+/// INTEGRATION TEST
+///
 /// This test case tests the Authentication
 fn test_authed_write_and_read() {
     let test_name = "test_authed_write_and_read";
@@ -195,32 +221,6 @@ fn test_wrong_authed_write_and_read() {
 #[test]
 /// INTEGRATION TEST
 ///
-/// This test case tests connection error
-fn test_connection_error() {
-    let test_name = "test_connection_error";
-    let client = InfluxDbClient::new("http://localhost:10086", test_name)
-        .with_auth("nopriv_user", "password");
-    let read_query = InfluxDbQuery::raw_read_query("SELECT * FROM weather");
-    let read_result = get_runtime().block_on(client.query(&read_query));
-    assert!(
-        read_result.is_err(),
-        format!("Should be an error: {}", read_result.unwrap_err())
-    );
-    match read_result {
-        Err(InfluxDbError::ConnectionError{..}) => assert!(true),
-        _ => assert!(
-            false,
-            format!(
-                "Should cause a ConnectionError: {}",
-                read_result.unwrap_err()
-            )
-        ),
-    }
-}
-
-#[test]
-/// INTEGRATION TEST
-///
 /// This test case tests the Authentication
 fn test_non_authed_write_and_read() {
     let test_name = "test_non_authed_write_and_read";
@@ -278,6 +278,7 @@ fn test_non_authed_write_and_read() {
         ),
     }
 }
+
 
 #[test]
 /// INTEGRATION TEST


### PR DESCRIPTION
Open up for discussion, a PR for adding Authentication.

Currently the URL generation has a lot of repeated code. My solution to add the auth parameters only when needed feels a little bit hacky currently. Setting db and auth parameters can be done before the if-statement. 
Are there arguments against this auth method (Params in URL)? Should we support all of the three possibilities (Basic auth, Query parameters in the URL and in the body )

Testing needs to be added as well.

Closes #9 