### PR TITLE
Added + Send to InfluxDbClient.query()

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -184,7 +184,7 @@ impl InfluxDbClient {
     /// a [`InfluxDbError`] variant will be returned.
     ///
     /// [`InfluxDbError`]: enum.InfluxDbError.html
-    pub fn query<Q>(&self, q: &Q) -> Box<dyn Future<Item = String, Error = InfluxDbError>>
+    pub fn query<Q>(&self, q: &Q) -> Box<dyn Future<Item = String, Error = InfluxDbError> + Send>
     where
         Q: Any + InfluxDbQuery,
     {


### PR DESCRIPTION
Added `+ Send` to the return type of `InfluxDbClient.query()` so it can be used with `tokio::spawn()` as demonstrated here: https://github.com/aisrael/tokio-influxdb/blob/master/src/main.rs#L11

Fixes #11 