### PR TITLE
Fix License formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Gero Gerke <11deutron11@gmail.com>"]
 edition = "2018"
 description = "InfluxDB Driver for Rust"
 keywords = ["influxdb", "database", "influx"]
-license-file = "LICENSE.md"
+license = "MIT"
 readme = "README.md"
-include = ["src/**/*", "tests/**/*", "Cargo.toml", "LICENSE.md"]
+include = ["src/**/*", "tests/**/*", "Cargo.toml", "LICENSE"]
 repository = "https://github.com/Empty2k12/influxdb-rust"
 
 [badges]

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,3 @@
-The MIT License
-
 Copyright (c) 2019 Gero Gerke https://gero.dev/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Adjust the license so it matches the official format: https://opensource.org/licenses/MIT
This should fix #13 