### PR TITLE
Removed usage of `itertools`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,7 +410,6 @@ version = "0.0.4"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -424,14 +423,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "itertools"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1505,7 +1496,6 @@ dependencies = [
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
-"checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ coveralls = { repository = "Empty2k12/influxdb-rust", branch = "master", service
 reqwest = "0.9.17"
 futures = "0.1.27"
 tokio = "0.1.20"
-itertools = "0.8"
 failure = "0.1.5"
 serde = { version = "1.0.92", optional = true }
 serde_json = { version = "1.0", optional = true }

--- a/src/query/write_query.rs
+++ b/src/query/write_query.rs
@@ -4,7 +4,6 @@
 
 use crate::error::InfluxDbError;
 use crate::query::{InfluxDbQuery, QueryType, Timestamp, ValidQuery};
-use itertools::Itertools;
 
 // todo: batch write queries
 
@@ -142,6 +141,7 @@ impl InfluxDbQuery for InfluxDbWriteQuery {
             .tags
             .iter()
             .map(|(tag, value)| format!("{tag}={value}", tag = tag, value = value))
+            .collect::<Vec<String>>()
             .join(",");
         if !tags.is_empty() {
             tags.insert_str(0, ",");
@@ -150,6 +150,7 @@ impl InfluxDbQuery for InfluxDbWriteQuery {
             .fields
             .iter()
             .map(|(field, value)| format!("{field}={value}", field = field, value = value))
+            .collect::<Vec<String>>()
             .join(",");
 
         Ok(ValidQuery(format!(


### PR DESCRIPTION
Itertools crate was used for ergonomic join on the iterator of strings. Changed this to use join on the vec of strings from the std lib, and dropped a dependency of the crate. Std lib join should even be more performant, since it preallocates the string length correctly, while itertools is doing the best effort it can.

Fixes #10