### PR TITLE
Lowercase Timestamps variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ let client = Client::new("http://localhost:8086", "test");
 // Let's write something to InfluxDB. First we're creating a
 // WriteQuery to write some data.
 // This creates a query which writes a new measurement into a series called `weather`
-let write_query = Query::write_query(Timestamp::NOW, "weather")
+let write_query = Query::write_query(Timestamp::Now, "weather")
     .add_field("temperature", 82);
 
 // Since this library is async by default, we're going to need a Runtime,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -170,7 +170,7 @@ impl Client {
     ///
     /// let client = Client::new("http://localhost:8086", "test");
     /// let _future = client.query(
-    ///     &Query::write_query(Timestamp::NOW, "weather")
+    ///     &Query::write_query(Timestamp::Now, "weather")
     ///         .add_field("temperature", 82)
     /// );
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@
 //! // Let's write something to InfluxDB. First we're creating a
 //! // WriteQuery to write some data.
 //! // This creates a query which writes a new measurement into a series called `weather`
-//! let write_query = Query::write_query(Timestamp::NOW, "weather")
+//! let write_query = Query::write_query(Timestamp::Now, "weather")
 //!     .add_field("temperature", 82);
 //!
 //! // Since this library is async by default, we're going to need a Runtime,

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -43,7 +43,7 @@ impl fmt::Display for Timestamp {
         match self {
             Now => write!(f, ""),
             Nanoseconds(ts) | Microseconds(ts) | Milliseconds(ts) | Seconds(ts) | Minutes(ts)
-            |   Hours(ts) => write!(f, "{}", ts),
+            | Hours(ts) => write!(f, "{}", ts),
         }
     }
 }

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -6,7 +6,7 @@
 //! ```rust
 //! use influxdb::{Query, Timestamp};
 //!
-//! let write_query = Query::write_query(Timestamp::NOW, "measurement")
+//! let write_query = Query::write_query(Timestamp::Now, "measurement")
 //!     .add_field("field1", 5)
 //!     .add_tag("author", "Gero")
 //!     .build();
@@ -28,22 +28,22 @@ use crate::{Error, ReadQuery, WriteQuery};
 
 #[derive(PartialEq)]
 pub enum Timestamp {
-    NOW,
-    NANOSECONDS(usize),
-    MICROSECONDS(usize),
-    MILLISECONDS(usize),
-    SECONDS(usize),
-    MINUTES(usize),
-    HOURS(usize),
+    Now,
+    Nanoseconds(usize),
+    Microseconds(usize),
+    Milliseconds(usize),
+    Seconds(usize),
+    Minutes(usize),
+    Hours(usize),
 }
 
 impl fmt::Display for Timestamp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use Timestamp::*;
         match self {
-            NOW => write!(f, ""),
-            NANOSECONDS(ts) | MICROSECONDS(ts) | MILLISECONDS(ts) | SECONDS(ts) | MINUTES(ts)
-            | HOURS(ts) => write!(f, "{}", ts),
+            Now => write!(f, ""),
+            Nanoseconds(ts) | Microseconds(ts) | Milliseconds(ts) | Seconds(ts) | Minutes(ts)
+            |   Hours(ts) => write!(f, "{}", ts),
         }
     }
 }
@@ -76,10 +76,10 @@ pub trait Query {
     /// ```rust
     /// use influxdb::{Query, Timestamp};
     ///
-    /// let invalid_query = Query::write_query(Timestamp::NOW, "measurement").build();
+    /// let invalid_query = Query::write_query(Timestamp::Now, "measurement").build();
     /// assert!(invalid_query.is_err());
     ///
-    /// let valid_query = Query::write_query(Timestamp::NOW, "measurement").add_field("myfield1", 11).build();
+    /// let valid_query = Query::write_query(Timestamp::Now, "measurement").add_field("myfield1", 11).build();
     /// assert!(valid_query.is_ok());
     /// ```
     fn build(&self) -> Result<ValidQuery, Error>;
@@ -95,7 +95,7 @@ impl dyn Query {
     /// ```rust
     /// use influxdb::{Query, Timestamp};
     ///
-    /// Query::write_query(Timestamp::NOW, "measurement"); // Is of type [`WriteQuery`](crate::WriteQuery)
+    /// Query::write_query(Timestamp::Now, "measurement"); // Is of type [`WriteQuery`](crate::WriteQuery)
     /// ```
     pub fn write_query<S>(timestamp: Timestamp, measurement: S) -> WriteQuery
     where
@@ -174,11 +174,11 @@ mod tests {
 
     #[test]
     fn test_format_for_timestamp_now() {
-        assert!(format!("{}", Timestamp::NOW) == "");
+        assert!(format!("{}", Timestamp::Now) == "");
     }
 
     #[test]
     fn test_format_for_timestamp_else() {
-        assert!(format!("{}", Timestamp::NANOSECONDS(100)) == "100");
+        assert!(format!("{}", Timestamp::Nanoseconds(100)) == "100");
     }
 }

--- a/src/query/write_query.rs
+++ b/src/query/write_query.rs
@@ -56,7 +56,7 @@ impl WriteQuery {
     /// ```rust
     /// use influxdb::{Query, Timestamp};
     ///
-    /// Query::write_query(Timestamp::NOW, "measurement").add_field("field1", 5).build();
+    /// Query::write_query(Timestamp::Now, "measurement").add_field("field1", 5).build();
     /// ```
     pub fn add_field<S, F>(mut self, tag: S, value: F) -> Self
     where
@@ -77,7 +77,7 @@ impl WriteQuery {
     /// ```rust
     /// use influxdb::{Query, Timestamp};
     ///
-    /// Query::write_query(Timestamp::NOW, "measurement")
+    /// Query::write_query(Timestamp::Now, "measurement")
     ///     .add_tag("field1", 5); // calling `.build()` now would result in a `Err(Error::InvalidQueryError)`
     /// ```
     pub fn add_tag<S, I>(mut self, tag: S, value: I) -> Self
@@ -92,13 +92,13 @@ impl WriteQuery {
 
     pub fn get_precision(&self) -> String {
         let modifier = match self.timestamp {
-            Timestamp::NOW => return String::from(""),
-            Timestamp::NANOSECONDS(_) => "ns",
-            Timestamp::MICROSECONDS(_) => "u",
-            Timestamp::MILLISECONDS(_) => "ms",
-            Timestamp::SECONDS(_) => "s",
-            Timestamp::MINUTES(_) => "m",
-            Timestamp::HOURS(_) => "h",
+            Timestamp::Now => return String::from(""),
+            Timestamp::Nanoseconds(_) => "ns",
+            Timestamp::Microseconds(_) => "u",
+            Timestamp::Milliseconds(_) => "ms",
+            Timestamp::Seconds(_) => "s",
+            Timestamp::Minutes(_) => "m",
+            Timestamp::Hours(_) => "h",
         };
         modifier.to_string()
     }
@@ -178,7 +178,7 @@ impl Query for WriteQuery {
             tags = tags,
             fields = fields,
             time = match self.timestamp {
-                Timestamp::NOW => String::from(""),
+                Timestamp::Now => String::from(""),
                 _ => format!(" {}", self.timestamp),
             }
         )))
@@ -195,14 +195,14 @@ mod tests {
 
     #[test]
     fn test_write_builder_empty_query() {
-        let query = Query::write_query(Timestamp::HOURS(5), "marina_3").build();
+        let query = Query::write_query(Timestamp::Hours(5), "marina_3").build();
 
         assert!(query.is_err(), "Query was not empty");
     }
 
     #[test]
     fn test_write_builder_single_field() {
-        let query = Query::write_query(Timestamp::HOURS(11), "weather")
+        let query = Query::write_query(Timestamp::Hours(11), "weather")
             .add_field("temperature", 82)
             .build();
 
@@ -212,7 +212,7 @@ mod tests {
 
     #[test]
     fn test_write_builder_multiple_fields() {
-        let query = Query::write_query(Timestamp::HOURS(11), "weather")
+        let query = Query::write_query(Timestamp::Hours(11), "weather")
             .add_field("temperature", 82)
             .add_field("wind_strength", 3.7)
             .build();
@@ -226,7 +226,7 @@ mod tests {
 
     #[test]
     fn test_write_builder_optional_fields() {
-        let query = Query::write_query(Timestamp::HOURS(11), "weather")
+        let query = Query::write_query(Timestamp::Hours(11), "weather")
             .add_field("temperature", Some(82u64))
             .add_field("wind_strength", <Option<u64>>::None)
             .build();
@@ -237,7 +237,7 @@ mod tests {
 
     #[test]
     fn test_write_builder_only_tags() {
-        let query = Query::write_query(Timestamp::HOURS(11), "weather")
+        let query = Query::write_query(Timestamp::Hours(11), "weather")
             .add_tag("season", "summer")
             .build();
 
@@ -246,7 +246,7 @@ mod tests {
 
     #[test]
     fn test_write_builder_full_query() {
-        let query = Query::write_query(Timestamp::HOURS(11), "weather")
+        let query = Query::write_query(Timestamp::Hours(11), "weather")
             .add_field("temperature", 82)
             .add_tag("location", "us-midwest")
             .add_tag("season", "summer")
@@ -263,7 +263,7 @@ mod tests {
     fn test_correct_query_type() {
         use crate::query::QueryType;
 
-        let query = Query::write_query(Timestamp::HOURS(11), "weather")
+        let query = Query::write_query(Timestamp::Hours(11), "weather")
             .add_field("temperature", 82)
             .add_tag("location", "us-midwest")
             .add_tag("season", "summer");

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -115,7 +115,7 @@ fn test_authed_write_and_read() {
 
     let client = Client::new("http://localhost:9086", test_name).with_auth("admin", "password");
     let write_query =
-        Query::write_query(Timestamp::HOURS(11), "weather").add_field("temperature", 82);
+        Query::write_query(Timestamp::Hours(11), "weather").add_field("temperature", 82);
     let write_result = get_runtime().block_on(client.query(&write_query));
     assert_result_ok(&write_result);
 
@@ -155,7 +155,7 @@ fn test_wrong_authed_write_and_read() {
     let client =
         Client::new("http://localhost:9086", test_name).with_auth("wrong_user", "password");
     let write_query =
-        Query::write_query(Timestamp::HOURS(11), "weather").add_field("temperature", 82);
+        Query::write_query(Timestamp::Hours(11), "weather").add_field("temperature", 82);
     let write_result = get_runtime().block_on(client.query(&write_query));
     assert_result_err(&write_result);
     match write_result {
@@ -216,7 +216,7 @@ fn test_non_authed_write_and_read() {
     };
     let non_authed_client = Client::new("http://localhost:9086", test_name);
     let write_query =
-        Query::write_query(Timestamp::HOURS(11), "weather").add_field("temperature", 82);
+        Query::write_query(Timestamp::Hours(11), "weather").add_field("temperature", 82);
     let write_result = get_runtime().block_on(non_authed_client.query(&write_query));
     assert_result_err(&write_result);
     match write_result {
@@ -254,7 +254,7 @@ fn test_write_and_read_field() {
 
     let client = create_client(test_name);
     let write_query =
-        Query::write_query(Timestamp::HOURS(11), "weather").add_field("temperature", 82);
+        Query::write_query(Timestamp::Hours(11), "weather").add_field("temperature", 82);
     let write_result = get_runtime().block_on(client.query(&write_query));
     assert_result_ok(&write_result);
 
@@ -286,7 +286,7 @@ fn test_write_and_read_option() {
 
     let client = create_client(test_name);
     // Todo: Convert this to derive based insert for easier comparison of structs
-    let write_query = Query::write_query(Timestamp::HOURS(11), "weather")
+    let write_query = Query::write_query(Timestamp::Hours(11), "weather")
         .add_field("temperature", 82)
         .add_field("wind_strength", <Option<u64>>::None);
     let write_result = get_runtime().block_on(client.query(&write_query));
@@ -338,7 +338,7 @@ fn test_json_query() {
 
     // todo: implement deriving so objects can easily be placed in InfluxDB
     let write_query =
-        Query::write_query(Timestamp::HOURS(11), "weather").add_field("temperature", 82);
+        Query::write_query(Timestamp::Hours(11), "weather").add_field("temperature", 82);
     let write_result = get_runtime().block_on(client.query(&write_query));
     assert_result_ok(&write_result);
 
@@ -385,11 +385,11 @@ fn test_json_query_vec() {
 
     let client = create_client(test_name);
     let write_query1 =
-        Query::write_query(Timestamp::HOURS(11), "temperature_vec").add_field("temperature", 16);
+        Query::write_query(Timestamp::Hours(11), "temperature_vec").add_field("temperature", 16);
     let write_query2 =
-        Query::write_query(Timestamp::HOURS(12), "temperature_vec").add_field("temperature", 17);
+        Query::write_query(Timestamp::Hours(12), "temperature_vec").add_field("temperature", 17);
     let write_query3 =
-        Query::write_query(Timestamp::HOURS(13), "temperature_vec").add_field("temperature", 18);
+        Query::write_query(Timestamp::Hours(13), "temperature_vec").add_field("temperature", 18);
 
     let _write_result = get_runtime().block_on(client.query(&write_query1));
     let _write_result2 = get_runtime().block_on(client.query(&write_query2));
@@ -442,9 +442,9 @@ fn test_serde_multi_query() {
 
     let client = create_client(test_name);
     let write_query =
-        Query::write_query(Timestamp::HOURS(11), "temperature").add_field("temperature", 16);
+        Query::write_query(Timestamp::Hours(11), "temperature").add_field("temperature", 16);
     let write_query2 =
-        Query::write_query(Timestamp::HOURS(11), "humidity").add_field("humidity", 69);
+        Query::write_query(Timestamp::Hours(11), "humidity").add_field("humidity", 69);
 
     let write_result = get_runtime().block_on(client.query(&write_query));
     let write_result2 = get_runtime().block_on(client.query(&write_query2));


### PR DESCRIPTION
## Description
I changed timestamp variants form UPPERCASE to TitleCase. Fixes #39

### Checklist
- [x] Formatted code using `cargo fmt --all`
- [x] Linted code using clippy `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Updated README.md using `cargo readme > README.md`
- [ ] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [ ] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment