### PR TITLE
Chrono types for Timestamp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,5 +76,5 @@ matrix:
 script: |
     export RUST_BACKTRACE=1 &&
     cargo build &&
-    cargo test &&
+    cargo test --all-features &&
     cargo doc --no-deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,29 +43,6 @@ matrix:
               - cargo fmt --all -- --check
               - cargo clippy --all-targets --all-features -- -D warnings
 
-        - env: NAME='cargo-travis'
-          sudo: required
-          before_script:
-              - cargo install cargo-update || echo "cargo-update already installed"
-              - cargo install cargo-travis || echo "cargo-travis already installed"
-              - cargo install-update -a
-          script:
-              - |
-                  cargo build &&
-                  cargo coverage &&
-                  wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&
-                  tar xzf master.tar.gz && mkdir kcov-master/build && cd kcov-master/build && cmake .. && make &&
-                  sudo make install && cd ../.. &&
-                  kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo --exclude-path=./tests target/kcov target/debug/influxdb-*
-          addons:
-              apt:
-                  packages:
-                      - libcurl4-openssl-dev
-                      - libelf-dev
-                      - libdw-dev
-                      - binutils-dev
-                      - cmake
-
         - rust: stable
           env: NAME='readme-check'
           before_script:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,6 @@ serde = { version = "1.0.92", optional = true }
 serde_json = { version = "1.0", optional = true }
 chrono = { version = "0.4.9", optional = true }
 
-chrono = { version = "0.4.9" }
-
 [features]
 use-serde = ["serde", "serde_json"]
 chrono_timestamps = ["chrono"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ serde = { version = "1.0.92", optional = true }
 serde_json = { version = "1.0", optional = true }
 chrono = { version = "0.4.9", optional = true }
 
-[dev-dependencies]
 chrono = { version = "0.4.9" }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,6 @@ include = ["src/**/*", "tests/**/*", "Cargo.toml", "LICENSE"]
 repository = "https://github.com/Empty2k12/influxdb-rust"
 
 [badges]
-travis-ci = { repository = "Empty2k12/influxdb-rust", branch = "master" }
-coveralls = { repository = "Empty2k12/influxdb-rust", branch = "master", service = "github" }
 
 [dependencies]
 reqwest = "0.9.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,12 @@ tokio = "0.1.20"
 failure = "0.1.5"
 serde = { version = "1.0.92", optional = true }
 serde_json = { version = "1.0", optional = true }
+chrono = { version = "0.4.9", optional = true }
+
+[dev-dependencies]
+chrono = { version = "0.4.9" }
 
 [features]
 use-serde = ["serde", "serde_json"]
+chrono_timestamps = ["chrono"]
 default = ["use-serde"]

--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@
     <a href="https://travis-ci.org/Empty2k12/influxdb-rust">
         <img src="https://travis-ci.org/Empty2k12/influxdb-rust.svg?branch=master" alt='Build Status' />
     </a>
-    <a href="https://coveralls.io/github/Empty2k12/influxdb-rust?branch=master">
-        <img src="https://coveralls.io/repos/github/Empty2k12/influxdb-rust/badge.svg?branch=master" alt='Coverage Status' />
-    </a>
     <a href="https://docs.rs/crate/influxdb">
         <img src="https://docs.rs/influxdb/badge.svg" alt='Documentation Status' />
     </a>

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Pull requests are always welcome. See [Contributing](https://github.com/Empty2k1
 -   Optional Serde Support for Deserialization
 -   Running multiple queries in one request (e.g. `SELECT * FROM weather_berlin; SELECT * FROM weather_london`)
 -   Authenticated and Unauthenticated Connections
+-  Optional conversion between `Timestamp` and `Chrono::DateTime<Utc>` via `chrono_timestamps` compilation feature
 
 ### Planned Features
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ Pull requests are always welcome. See [Contributing](https://github.com/Empty2k1
 -   Optional Serde Support for Deserialization
 -   Running multiple queries in one request (e.g. `SELECT * FROM weather_berlin; SELECT * FROM weather_london`)
 -   Authenticated and Unauthenticated Connections
--  Optional conversion between `Timestamp` and `Chrono::DateTime<Utc>` via `chrono_timestamps` compilation feature
-
+-   Optional conversion between `Timestamp` and `Chrono::DateTime<Utc>` via `chrono_timestamps` compilation feature
 ### Planned Features
 
 -   Read Query Builder instead of supplying raw queries

--- a/README.tpl
+++ b/README.tpl
@@ -16,9 +16,6 @@
     <a href="https://travis-ci.org/Empty2k12/influxdb-rust">
         <img src="https://travis-ci.org/Empty2k12/influxdb-rust.svg?branch=master" alt='Build Status' />
     </a>
-    <a href="https://coveralls.io/github/Empty2k12/influxdb-rust?branch=master">
-        <img src="https://coveralls.io/repos/github/Empty2k12/influxdb-rust/badge.svg?branch=master" alt='Coverage Status' />
-    </a>
     <a href="https://docs.rs/crate/influxdb">
         <img src="https://docs.rs/influxdb/badge.svg" alt='Documentation Status' />
     </a>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! -   Optional Serde Support for Deserialization
 //! -   Running multiple queries in one request (e.g. `SELECT * FROM weather_berlin; SELECT * FROM weather_london`)
 //! -   Authenticated and Unauthenticated Connections
-//!
+//! -   Optional conversion between `Timestamp` and `Chrono::DateTime<Utc>` via `chrono_timestamps` compilation feature
 //! ## Planned Features
 //!
 //! -   Read Query Builder instead of supplying raw queries

--- a/src/query/consts.rs
+++ b/src/query/consts.rs
@@ -1,0 +1,7 @@
+pub const MINUTES_PER_HOUR: usize = 60;
+pub const SECONDS_PER_MINUTE: usize = 60;
+pub const MILLIS_PER_SECOND: usize = 1000;
+pub const NANOS_PER_MILLI: usize = 1_000_000;
+
+#[cfg(test)]
+pub const MICROS_PER_NANO: usize = 1000;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -91,7 +91,7 @@ impl Into<DateTime<Utc>> for Timestamp {
     }
 }
 
-#[cfg(any(test, feature = "chrono_timestamps"))]
+#[cfg(feature = "chrono_timestamps")]
 impl<T> From<DateTime<T>> for Timestamp
 where
     T: TimeZone,

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -85,7 +85,7 @@ impl Into<DateTime<Utc>> for Timestamp {
 #[cfg(any(test, feature = "chrono_timestamps"))]
 impl From<DateTime<Utc>> for Timestamp {
     fn from(date_time: DateTime<Utc>) -> Self {
-        Timestamp::Seconds(date_time.timestamp() as usize)
+        Timestamp::Milliseconds(date_time.timestamp_millis() as usize)
     }
 }
 
@@ -202,6 +202,11 @@ mod tests {
     use crate::query::{Timestamp, ValidQuery};
     use chrono::prelude::{DateTime, TimeZone, Utc};
 
+    const MINUTES_PER_HOUR: i64 = 60;
+    const SECONDS_PER_MINUTE: i64 = 60;
+    const MILLIS_PER_SECOND: i64 = 1000;
+    const MICROS_PER_NANO: i64 = 1000;
+
     #[test]
     fn test_equality_str() {
         assert_eq!(ValidQuery::from("hello"), "hello");
@@ -232,26 +237,32 @@ mod tests {
     }
     #[test]
     fn test_chrono_datetime_from_timestamp_hours() {
-        let datetime_from_timestamp: DateTime<Utc> = Timestamp::Hours(1).into();
+        let datetime_from_timestamp: DateTime<Utc> = Timestamp::Hours(2).into();
         assert_eq!(
-            Utc.timestamp_millis(1 * 60 * 60 * 1000),
+            Utc.timestamp_millis(2 * MINUTES_PER_HOUR * SECONDS_PER_MINUTE * MILLIS_PER_SECOND),
             datetime_from_timestamp
         )
     }
     #[test]
     fn test_chrono_datetime_from_timestamp_minutes() {
-        let datetime_from_timestamp: DateTime<Utc> = Timestamp::Minutes(1).into();
-        assert_eq!(Utc.timestamp_millis(1 * 60 * 1000), datetime_from_timestamp)
+        let datetime_from_timestamp: DateTime<Utc> = Timestamp::Minutes(2).into();
+        assert_eq!(
+            Utc.timestamp_millis(2 * SECONDS_PER_MINUTE * MILLIS_PER_SECOND),
+            datetime_from_timestamp
+        )
     }
     #[test]
     fn test_chrono_datetime_from_timestamp_seconds() {
-        let datetime_from_timestamp: DateTime<Utc> = Timestamp::Seconds(1).into();
-        assert_eq!(Utc.timestamp_millis(1 * 1000), datetime_from_timestamp)
+        let datetime_from_timestamp: DateTime<Utc> = Timestamp::Seconds(2).into();
+        assert_eq!(
+            Utc.timestamp_millis(2 * MILLIS_PER_SECOND),
+            datetime_from_timestamp
+        )
     }
     #[test]
     fn test_chrono_datetime_from_timestamp_millis() {
-        let datetime_from_timestamp: DateTime<Utc> = Timestamp::Milliseconds(1).into();
-        assert_eq!(Utc.timestamp_millis(1), datetime_from_timestamp)
+        let datetime_from_timestamp: DateTime<Utc> = Timestamp::Milliseconds(2).into();
+        assert_eq!(Utc.timestamp_millis(2), datetime_from_timestamp)
     }
 
     #[test]
@@ -263,12 +274,15 @@ mod tests {
     #[test]
     fn test_chrono_datetime_from_timestamp_micros() {
         let datetime_from_timestamp: DateTime<Utc> = Timestamp::Microseconds(1).into();
-        assert_eq!(Utc.timestamp_nanos(1 / 1000), datetime_from_timestamp)
+        assert_eq!(
+            Utc.timestamp_nanos(1 / MICROS_PER_NANO),
+            datetime_from_timestamp
+        )
     }
 
     #[test]
     fn test_timestamp_from_chrono_date() {
-        let timestamp_from_datetime: Timestamp = Utc.ymd(1970, 1, 1).and_hms(0, 1, 1).into();
-        assert_eq!(Timestamp::Seconds(61), timestamp_from_datetime)
+        let timestamp_from_datetime: Timestamp = Utc.ymd(1970, 1, 1).and_hms(0, 0, 1).into();
+        assert_eq!(Timestamp::Milliseconds(1000), timestamp_from_datetime)
     }
 }

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -19,21 +19,26 @@
 //! assert!(read_query.is_ok());
 //! ```
 
-#[cfg(any(test, feature = "chrono_timestamps"))]
+#[cfg(feature = "chrono_timestamps")]
 extern crate chrono;
-#[cfg(any(test, feature = "chrono_timestamps"))]
+
+#[cfg(feature = "chrono_timestamps")]
 use chrono::prelude::{DateTime, TimeZone, Utc};
-#[cfg(any(test, feature = "chrono_timestamps"))]
+#[cfg(feature = "chrono_timestamps")]
 use std::convert::TryInto;
 
+#[cfg(feature = "chrono_timestamps")]
+pub mod consts;
 pub mod read_query;
 pub mod write_query;
-
 use std::fmt;
 
 use crate::{Error, ReadQuery, WriteQuery};
 
-#[derive(PartialEq, Debug)]
+#[cfg(feature = "chrono_timestamps")]
+use consts::{MILLIS_PER_SECOND, MINUTES_PER_HOUR, NANOS_PER_MILLI, SECONDS_PER_MINUTE};
+
+#[derive(PartialEq, Debug, Copy, Clone)]
 pub enum Timestamp {
     Now,
     Nanoseconds(usize),
@@ -61,19 +66,23 @@ impl Into<DateTime<Utc>> for Timestamp {
         match self {
             Timestamp::Now => Utc::now(),
             Timestamp::Hours(h) => {
-                let millis = h * 60 * 60 * 1000;
-                Utc.timestamp_millis(millis.try_into().unwrap())
+                let nanos =
+                    h * MINUTES_PER_HOUR * SECONDS_PER_MINUTE * MILLIS_PER_SECOND * NANOS_PER_MILLI;
+                Utc.timestamp_nanos(nanos.try_into().unwrap())
             }
             Timestamp::Minutes(m) => {
-                let millis = m * 60 * 1000;
-                Utc.timestamp_millis(millis.try_into().unwrap())
+                let nanos = m * SECONDS_PER_MINUTE * MILLIS_PER_SECOND * NANOS_PER_MILLI;
+                Utc.timestamp_nanos(nanos.try_into().unwrap())
             }
-            Timestamp::Seconds(m) => {
-                let millis = m * 1000;
-                Utc.timestamp_millis(millis.try_into().unwrap())
+            Timestamp::Seconds(s) => {
+                let nanos = s * MILLIS_PER_SECOND * NANOS_PER_MILLI;
+                Utc.timestamp_nanos(nanos.try_into().unwrap())
             }
-            Timestamp::Milliseconds(millis) => Utc.timestamp_millis(millis.try_into().unwrap()),
-            Timestamp::Nanoseconds(ns) => Utc.timestamp_nanos(ns.try_into().unwrap()),
+            Timestamp::Milliseconds(millis) => {
+                let nanos = millis * NANOS_PER_MILLI;
+                Utc.timestamp_nanos(nanos.try_into().unwrap())
+            }
+            Timestamp::Nanoseconds(nanos) => Utc.timestamp_nanos(nanos.try_into().unwrap()),
             Timestamp::Microseconds(mis) => {
                 let nanos = mis / 10000;
                 Utc.timestamp_nanos(nanos.try_into().unwrap())
@@ -88,7 +97,7 @@ where
     T: TimeZone,
 {
     fn from(date_time: DateTime<T>) -> Self {
-        Timestamp::Milliseconds(date_time.timestamp_millis() as usize)
+        Timestamp::Nanoseconds(date_time.timestamp_nanos() as usize)
     }
 }
 
@@ -201,15 +210,17 @@ pub enum QueryType {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "chrono_timestamps")]
+    use std::convert::TryInto;
+    #[cfg(feature = "chrono_timestamps")]
     extern crate chrono;
+    #[cfg(feature = "chrono_timestamps")]
+    use super::consts::{
+        MICROS_PER_NANO, MILLIS_PER_SECOND, MINUTES_PER_HOUR, NANOS_PER_MILLI, SECONDS_PER_MINUTE,
+    };
     use crate::query::{Timestamp, ValidQuery};
+    #[cfg(feature = "chrono_timestamps")]
     use chrono::prelude::{DateTime, TimeZone, Utc};
-
-    const MINUTES_PER_HOUR: i64 = 60;
-    const SECONDS_PER_MINUTE: i64 = 60;
-    const MILLIS_PER_SECOND: i64 = 1000;
-    const MICROS_PER_NANO: i64 = 1000;
-
     #[test]
     fn test_equality_str() {
         assert_eq!(ValidQuery::from("hello"), "hello");
@@ -233,59 +244,84 @@ mod tests {
         assert!(format!("{}", Timestamp::Nanoseconds(100)) == "100");
     }
 
+    #[cfg(feature = "chrono_timestamps")]
     #[test]
     fn test_chrono_datetime_from_timestamp_now() {
         let datetime_from_timestamp: DateTime<Utc> = Timestamp::Now.into();
         assert_eq!(Utc::now().date(), datetime_from_timestamp.date())
     }
+    #[cfg(feature = "chrono_timestamps")]
     #[test]
     fn test_chrono_datetime_from_timestamp_hours() {
         let datetime_from_timestamp: DateTime<Utc> = Timestamp::Hours(2).into();
         assert_eq!(
-            Utc.timestamp_millis(2 * MINUTES_PER_HOUR * SECONDS_PER_MINUTE * MILLIS_PER_SECOND),
+            Utc.timestamp_nanos(
+                (2 * MINUTES_PER_HOUR * SECONDS_PER_MINUTE * MILLIS_PER_SECOND * NANOS_PER_MILLI)
+                    .try_into()
+                    .unwrap()
+            ),
             datetime_from_timestamp
         )
     }
+    #[cfg(feature = "chrono_timestamps")]
     #[test]
     fn test_chrono_datetime_from_timestamp_minutes() {
         let datetime_from_timestamp: DateTime<Utc> = Timestamp::Minutes(2).into();
         assert_eq!(
-            Utc.timestamp_millis(2 * SECONDS_PER_MINUTE * MILLIS_PER_SECOND),
+            Utc.timestamp_nanos(
+                (2 * SECONDS_PER_MINUTE * MILLIS_PER_SECOND * NANOS_PER_MILLI)
+                    .try_into()
+                    .unwrap()
+            ),
             datetime_from_timestamp
         )
     }
+    #[cfg(feature = "chrono_timestamps")]
     #[test]
     fn test_chrono_datetime_from_timestamp_seconds() {
         let datetime_from_timestamp: DateTime<Utc> = Timestamp::Seconds(2).into();
         assert_eq!(
-            Utc.timestamp_millis(2 * MILLIS_PER_SECOND),
+            Utc.timestamp_nanos(
+                (2 * MILLIS_PER_SECOND * NANOS_PER_MILLI)
+                    .try_into()
+                    .unwrap()
+            ),
             datetime_from_timestamp
         )
     }
+    #[cfg(feature = "chrono_timestamps")]
     #[test]
     fn test_chrono_datetime_from_timestamp_millis() {
         let datetime_from_timestamp: DateTime<Utc> = Timestamp::Milliseconds(2).into();
-        assert_eq!(Utc.timestamp_millis(2), datetime_from_timestamp)
+        assert_eq!(
+            Utc.timestamp_nanos((2 * NANOS_PER_MILLI).try_into().unwrap()),
+            datetime_from_timestamp
+        )
     }
 
+    #[cfg(feature = "chrono_timestamps")]
     #[test]
     fn test_chrono_datetime_from_timestamp_nanos() {
         let datetime_from_timestamp: DateTime<Utc> = Timestamp::Nanoseconds(1).into();
         assert_eq!(Utc.timestamp_nanos(1), datetime_from_timestamp)
     }
-
+    #[cfg(feature = "chrono_timestamps")]
     #[test]
     fn test_chrono_datetime_from_timestamp_micros() {
         let datetime_from_timestamp: DateTime<Utc> = Timestamp::Microseconds(1).into();
         assert_eq!(
-            Utc.timestamp_nanos(1 / MICROS_PER_NANO),
+            Utc.timestamp_nanos((1 / MICROS_PER_NANO).try_into().unwrap()),
             datetime_from_timestamp
         )
     }
 
+    #[cfg(feature = "chrono_timestamps")]
     #[test]
     fn test_timestamp_from_chrono_date() {
         let timestamp_from_datetime: Timestamp = Utc.ymd(1970, 1, 1).and_hms(0, 0, 1).into();
-        assert_eq!(Timestamp::Milliseconds(1000), timestamp_from_datetime)
+        assert_eq!(
+            Timestamp::Nanoseconds(MILLIS_PER_SECOND * NANOS_PER_MILLI),
+            timestamp_from_datetime
+        )
     }
 }

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -60,7 +60,7 @@ impl fmt::Display for Timestamp {
     }
 }
 
-#[cfg(any(test, feature = "chrono_timestamps"))]
+#[cfg(feature = "chrono_timestamps")]
 impl Into<DateTime<Utc>> for Timestamp {
     fn into(self) -> DateTime<Utc> {
         match self {

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -83,8 +83,11 @@ impl Into<DateTime<Utc>> for Timestamp {
 }
 
 #[cfg(any(test, feature = "chrono_timestamps"))]
-impl From<DateTime<Utc>> for Timestamp {
-    fn from(date_time: DateTime<Utc>) -> Self {
+impl<T> From<DateTime<T>> for Timestamp
+where
+    T: TimeZone,
+{
+    fn from(date_time: DateTime<T>) -> Self {
         Timestamp::Milliseconds(date_time.timestamp_millis() as usize)
     }
 }


### PR DESCRIPTION
## Description
Fixes #35.
- Each branch of the `Into` implementation casts everything to a `DateTime<Utc>` with at least millisecond precision. I figure the caller can cast the value to a timezone if needed.
-  I'm not sure if I'm representing `Timestamp`s the preferred way in UTC-land, because I'm not super familiar with how influxdb works. For example, `Timestamp::Hours(3)` probably doesn't mean three hours from the epoch, but for now I kept it consistent.
- The `From<DateTime>` implementation creates a `Timestamp::Milliseconds` from a given date. It will work for any DateTime object that implements `TimeZone`.
- these implementations are behind the `chrono_timestamps` compilation feature.


I hope this is sort of what you're looking for; let me know if you want me to take it in a different direction or implement more chrono converters.

### Checklist
- [x] Formatted code using `cargo fmt --all`
- [x] Linted code using clippy `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Updated README.md using `cargo readme > README.md`
- [x] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [x] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment