### PR TITLE
Remove Code Coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,35 +43,12 @@ matrix:
               - cargo fmt --all -- --check
               - cargo clippy --all-targets --all-features -- -D warnings
 
-        - env: NAME='cargo-travis'
-          sudo: required
-          before_script:
-              - cargo install cargo-update || echo "cargo-update already installed"
-              - cargo install cargo-travis || echo "cargo-travis already installed"
-              - cargo install-update -a
-          script:
-              - |
-                  cargo build &&
-                  cargo coverage &&
-                  wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&
-                  tar xzf master.tar.gz && mkdir kcov-master/build && cd kcov-master/build && cmake .. && make &&
-                  sudo make install && cd ../.. &&
-                  kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo --exclude-path=./tests target/kcov target/debug/influxdb-*
-          addons:
-              apt:
-                  packages:
-                      - libcurl4-openssl-dev
-                      - libelf-dev
-                      - libdw-dev
-                      - binutils-dev
-                      - cmake
-
         - rust: stable
           env: NAME='readme-check'
           before_script:
-            - bash auxiliary/update_cargo-readme.sh
+              - bash auxiliary/update_cargo-readme.sh
           script:
-            - bash auxiliary/check_readme_consistency.sh
+              - bash auxiliary/check_readme_consistency.sh
 
 script: |
     export RUST_BACKTRACE=1 &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ repository = "https://github.com/Empty2k12/influxdb-rust"
 
 [badges]
 travis-ci = { repository = "Empty2k12/influxdb-rust", branch = "master" }
-coveralls = { repository = "Empty2k12/influxdb-rust", branch = "master", service = "github" }
 
 [dependencies]
 reqwest = "0.9.17"

--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@
     <a href="https://travis-ci.org/Empty2k12/influxdb-rust">
         <img src="https://travis-ci.org/Empty2k12/influxdb-rust.svg?branch=master" alt='Build Status' />
     </a>
-    <a href="https://coveralls.io/github/Empty2k12/influxdb-rust?branch=master">
-        <img src="https://coveralls.io/repos/github/Empty2k12/influxdb-rust/badge.svg?branch=master" alt='Coverage Status' />
-    </a>
     <a href="https://docs.rs/crate/influxdb">
         <img src="https://docs.rs/influxdb/badge.svg" alt='Documentation Status' />
     </a>
@@ -99,6 +96,5 @@ in the repository.
 ## License
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-
 
 @ 2019 Gero Gerke, All rights reserved.

--- a/README.tpl
+++ b/README.tpl
@@ -16,9 +16,6 @@
     <a href="https://travis-ci.org/Empty2k12/influxdb-rust">
         <img src="https://travis-ci.org/Empty2k12/influxdb-rust.svg?branch=master" alt='Build Status' />
     </a>
-    <a href="https://coveralls.io/github/Empty2k12/influxdb-rust?branch=master">
-        <img src="https://coveralls.io/repos/github/Empty2k12/influxdb-rust/badge.svg?branch=master" alt='Coverage Status' />
-    </a>
     <a href="https://docs.rs/crate/influxdb">
         <img src="https://docs.rs/influxdb/badge.svg" alt='Documentation Status' />
     </a>
@@ -28,5 +25,4 @@
 </p>
 
 {{readme}}
-
 @ 2019 Gero Gerke, All rights reserved.


### PR DESCRIPTION
## Description

Code Coverage is broken in Rust. Wrong lines are covered and features are incorrectly detected. This PR removes it and adds #43 as a tracking issue to add it back once working solutions are built and useable in this project.

### Checklist
- [ ] Formatted code using `cargo fmt --all`
- [ ] Linted code using clippy `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Updated README.md using `cargo readme > README.md`
- [ ] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [ ] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment