### PR TITLE
Change type of timestamp-variants to u128

### DIFF
--- a/src/query/consts.rs
+++ b/src/query/consts.rs
@@ -1,7 +1,7 @@
-pub const MINUTES_PER_HOUR: usize = 60;
-pub const SECONDS_PER_MINUTE: usize = 60;
-pub const MILLIS_PER_SECOND: usize = 1000;
-pub const NANOS_PER_MILLI: usize = 1_000_000;
+pub const MINUTES_PER_HOUR: u128 = 60;
+pub const SECONDS_PER_MINUTE: u128 = 60;
+pub const MILLIS_PER_SECOND: u128 = 1000;
+pub const NANOS_PER_MILLI: u128 = 1_000_000;
 
 #[cfg(test)]
-pub const MICROS_PER_NANO: usize = 1000;
+pub const MICROS_PER_NANO: u128 = 1000;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -41,12 +41,12 @@ use consts::{MILLIS_PER_SECOND, MINUTES_PER_HOUR, NANOS_PER_MILLI, SECONDS_PER_M
 #[derive(PartialEq, Debug, Copy, Clone)]
 pub enum Timestamp {
     Now,
-    Nanoseconds(usize),
-    Microseconds(usize),
-    Milliseconds(usize),
-    Seconds(usize),
-    Minutes(usize),
-    Hours(usize),
+    Nanoseconds(u128),
+    Microseconds(u128),
+    Milliseconds(u128),
+    Seconds(u128),
+    Minutes(u128),
+    Hours(u128),
 }
 
 impl fmt::Display for Timestamp {
@@ -97,7 +97,7 @@ where
     T: TimeZone,
 {
     fn from(date_time: DateTime<T>) -> Self {
-        Timestamp::Nanoseconds(date_time.timestamp_nanos() as usize)
+        Timestamp::Nanoseconds(date_time.timestamp_nanos() as u128)
     }
 }
 


### PR DESCRIPTION
## Description

change type of timestamp-variants to u128.

The constants in src/query/consts.rs are still usize, though I don't expect problems there. Should I change these too for good measure?

### Checklist
- [ ] Formatted code using `cargo fmt --all`
- [ ] Linted code using clippy `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Updated README.md using `cargo readme > README.md`
- [ ] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [ ] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment