### PR TITLE
Use `rfc3339` as default timestamp precision

### DIFF
--- a/src/query/write_query.rs
+++ b/src/query/write_query.rs
@@ -92,7 +92,7 @@ impl WriteQuery {
 
     pub fn get_precision(&self) -> String {
         let modifier = match self.timestamp {
-            Timestamp::Now => return String::from(""),
+            Timestamp::Now => "rfc3339",
             Timestamp::Nanoseconds(_) => "ns",
             Timestamp::Microseconds(_) => "u",
             Timestamp::Milliseconds(_) => "ms",


### PR DESCRIPTION
According to https://docs.influxdata.com/influxdb/v1.7/tools/shell/#precision-rfc3339-h-m-s-ms-u-ns, we should use rfc3339 instead of empty string as the default timestamp precision

### Checklist
- [x] Formatted code using `cargo fmt --all`
- [x] Linted code using clippy `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Updated README.md using `cargo readme > README.md`
- [x] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [x] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment