### PR TITLE
Fix whitespace handling

### DIFF
--- a/src/query/write_query.rs
+++ b/src/query/write_query.rs
@@ -121,7 +121,7 @@ impl Display for Type {
             Float(x) => write!(f, "{}", x),
             SignedInteger(x) => write!(f, "{}", x),
             UnsignedInteger(x) => write!(f, "{}", x),
-            Text(text) => write!(f, "\"{text}\"", text = text),
+            Text(text) => write!(f, "{text}", text = text.replace(" ", "\\ ")),
         }
     }
 }

--- a/src/query/write_query.rs
+++ b/src/query/write_query.rs
@@ -250,12 +250,13 @@ mod tests {
             .add_field("temperature", 82)
             .add_tag("location", "us-midwest")
             .add_tag("season", "summer")
+            .add_tag("space", "escape test")
             .build();
 
         assert!(query.is_ok(), "Query was empty");
         assert_eq!(
             query.unwrap(),
-            "weather,location=\"us-midwest\",season=\"summer\" temperature=82 11"
+            "weather,location=us-midwest,season=summer,space=escape\\ test temperature=82 11"
         );
     }
 


### PR DESCRIPTION
The whitespaces in tags and fields must be escaped with a backslash instead of surrounding it with double quotes.

I am not sure how to handle other special characters like \r, \n, or \t. This is not handled currently.

Closes #52 

