### PR TITLE
Fix Encoding/Escaping according to the InfluxDb Line-Protocol

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ serde_json = { version = "1.0.46", optional = true }
 regex = "1.3.4"
 lazy_static = "1.4.0"
 
+# This is a temporary work around to fix a Failure-derive compilation error
+# Should be removed when https://github.com/Empty2k12/influxdb-rust/issues/48 is being done
+quote = "=1.0.2"
+
 [features]
 use-serde = ["serde", "serde_json"]
 chrono_timestamps = ["chrono"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ futures = "0.3.4"
 reqwest = { version = "0.10.1", features = ["json"] }
 serde = { version = "1.0.104", features = ["derive"], optional = true }
 serde_json = { version = "1.0.46", optional = true }
+regex = "1.3.4"
+lazy_static = "1.4.0"
 
 [features]
 use-serde = ["serde", "serde_json"]

--- a/src/query/line_proto_term.rs
+++ b/src/query/line_proto_term.rs
@@ -1,0 +1,89 @@
+/// InfluxDB Line Protocol escaping helper module.
+/// https://docs.influxdata.com/influxdb/v1.7/write_protocols/line_protocol_tutorial/
+
+use crate::Type;
+use lazy_static::lazy_static;
+use regex::Regex;
+
+lazy_static! {
+    pub static ref COMMAS_SPACES: Regex = Regex::new("[, ]").unwrap();
+    pub static ref COMMAS_SPACES_EQUALS: Regex = Regex::new("[, =]").unwrap();
+    pub static ref QUOTES_SLASHES: Regex = Regex::new(r#"["\\]"#).unwrap();
+}
+
+pub enum LineProtoTerm<'a> {
+    Measurement(&'a str), // escape commas, spaces
+    TagKey(&'a str),      // escape commas, equals, spaces
+    TagValue(&'a str),    // escape commas, equals, spaces
+    FieldKey(&'a str),    // escape commas, equals, spaces
+    FieldValue(&'a Type), // escape quotes, backslashes + quote
+}
+
+impl LineProtoTerm<'_> {
+    pub fn escape(self) -> String {
+        use LineProtoTerm::*;
+        match self {
+            Measurement(x) => Self::escape_any(x, &*COMMAS_SPACES),
+            TagKey(x) | TagValue(x) | FieldKey(x) => Self::escape_any(x, &*COMMAS_SPACES_EQUALS),
+            FieldValue(x) => Self::escape_field_value(x),
+        }
+    }
+
+    fn escape_field_value(v: &Type) -> String {
+        use Type::*;
+        match v {
+            Boolean(v) => {
+                if *v {
+                    "true"
+                } else {
+                    "false"
+                }
+            }
+            .to_string(),
+            Float(v) => v.to_string(),
+            SignedInteger(v) => format!("{}i", v),
+            UnsignedInteger(v) => format!("{}i", v),
+            Text(v) => format!("\"{}\"", Self::escape_any(v, &*QUOTES_SLASHES)),
+        }
+    }
+
+    fn escape_any(s: &str, re: &Regex) -> String {
+        re.replace_all(s, r#"\$0"#).to_string()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::query::line_proto_term::LineProtoTerm::*;
+    use crate::Type;
+
+    #[test]
+    fn test() {
+        assert_eq!(Measurement(r#"wea", ther"#).escape(), r#"wea"\,\ ther"#);
+        assert_eq!(TagKey(r#"locat\ ,=ion"#).escape(), r#"locat\\ \,\=ion"#);
+
+        assert_eq!(FieldValue(&Type::Boolean(true)).escape(), r#"true"#);
+        assert_eq!(FieldValue(&Type::Boolean(false)).escape(), r#"false"#);
+
+        assert_eq!(FieldValue(&Type::Float(0.0)).escape(), r#"0"#);
+        assert_eq!(FieldValue(&Type::Float(-0.1)).escape(), r#"-0.1"#);
+
+        assert_eq!(FieldValue(&Type::SignedInteger(0)).escape(), r#"0i"#);
+        assert_eq!(FieldValue(&Type::SignedInteger(83)).escape(), r#"83i"#);
+
+        assert_eq!(FieldValue(&Type::Text("".into())).escape(), r#""""#);
+        assert_eq!(FieldValue(&Type::Text("0".into())).escape(), r#""0""#);
+        assert_eq!(FieldValue(&Type::Text("\"".into())).escape(), r#""\"""#);
+        assert_eq!(
+            FieldValue(&Type::Text(r#"locat"\ ,=ion"#.into())).escape(),
+            r#""locat\"\\ ,=ion""#
+        );
+    }
+
+    #[test]
+    fn test_empty_tag_value() {
+        // InfluxDB doesn't support empty tag values. But that's a job
+        // of a calling site to validate an entire write request.
+        assert_eq!(TagValue("").escape(), "");
+    }
+}

--- a/src/query/line_proto_term.rs
+++ b/src/query/line_proto_term.rs
@@ -1,6 +1,5 @@
 /// InfluxDB Line Protocol escaping helper module.
 /// https://docs.influxdata.com/influxdb/v1.7/write_protocols/line_protocol_tutorial/
-
 use crate::Type;
 use lazy_static::lazy_static;
 use regex::Regex;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -29,6 +29,7 @@ use std::convert::TryInto;
 
 #[cfg(feature = "chrono_timestamps")]
 pub mod consts;
+mod line_proto_term;
 pub mod read_query;
 pub mod write_query;
 use std::fmt;


### PR DESCRIPTION
## Description

This PR contains the following changes:
1. Don't quote tags, since quotes become a part of it in this case.
2. Pass rust ints as influxdb ints. In other case they are treated as floats.
3. Other escaping rules according to the [influxdb line protocol reference](https://docs.influxdata.com/influxdb/v1.7/write_protocols/line_protocol_tutorial/#quoting).

Tested it on ~1.2 million records during a conversion from mongodb. Better than nothing. 

Fixes #52, closes #53 

### Checklist
- [x] Formatted code using `cargo fmt --all`
- [x] Linted code using clippy `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Updated README.md using `cargo readme > README.md`
- [x] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [x] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment