### PR TITLE
Implemeting clone and debug for WriteQuery an ReadQuery.

### DIFF
--- a/influxdb/src/query/read_query.rs
+++ b/influxdb/src/query/read_query.rs
@@ -5,6 +5,7 @@
 use crate::query::{QueryType, ValidQuery};
 use crate::{Error, Query};
 
+#[derive(Debug, Clone)]
 pub struct ReadQuery {
     queries: Vec<String>,
 }

--- a/influxdb/src/query/write_query.rs
+++ b/influxdb/src/query/write_query.rs
@@ -27,6 +27,7 @@ impl<T: Into<Type>> WriteType for Option<T> {
 }
 
 /// Internal Representation of a Write query that has not yet been built
+#[derive(Debug, Clone)]
 pub struct WriteQuery {
     fields: Vec<(String, Type)>,
     tags: Vec<(String, Type)>,
@@ -105,6 +106,7 @@ impl WriteQuery {
     }
 }
 
+#[derive(Debug, Clone)]
 pub enum Type {
     Boolean(bool),
     Float(f64),


### PR DESCRIPTION
## Description

Making `ReadQuery` and `WriteQuery` `Debug` and `Clone` so they can be passed through channels.

### Checklist
- [X] Formatted code using `cargo fmt --all`
- [X] Linted code using clippy `cargo clippy --all-targets --all-features -- -D warnings`

Note: it appears that there were some errors before my commit:

> error: this import is redundant
>  --> influxdb/src/error.rs:2:1
>   |
> 2 | use reqwest;
>   | ^^^^^^^^^^^^ help: remove it entirely
>   |
>   = note: `-D clippy::single-component-path-imports` implied by `-D warnings`
>   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_component_path_imports
> 
> error: this import is redundant
>   --> influxdb/src/integrations/serde_integration.rs:52:1
>    |
> 52 | use serde_json;
>    | ^^^^^^^^^^^^^^^ help: remove it entirely
>    |
>    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_component_path_imports
> 
> error: this import is redundant
>  --> influxdb/src/error.rs:2:1
>   |
> 2 | use reqwest;
>   | ^^^^^^^^^^^^ help: remove it entirely
>   |
>   = note: `-D clippy::single-component-path-imports` implied by `-D warnings`
>   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_component_path_imports
> 
> error: this import is redundant
>   --> influxdb/src/integrations/serde_integration.rs:52:1
>    |
> 52 | use serde_json;
>    | ^^^^^^^^^^^^^^^ help: remove it entirely
>    |
>    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_component_path_imports
> 
> error: aborting due to 2 previous errors
> 
> error: could not compile `influxdb`.


- [X] Updated README.md using `cargo readme > README.md`
- [X] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [X] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment