### PR TITLE
Fix quotation marks of tag values and escaping of field values

### DIFF
--- a/influxdb/src/query/line_proto_term.rs
+++ b/influxdb/src/query/line_proto_term.rs
@@ -44,7 +44,7 @@ impl LineProtoTerm<'_> {
             Float(v) => v.to_string(),
             SignedInteger(v) => format!("{}i", v),
             UnsignedInteger(v) => format!("{}i", v),
-            Text(v) => format!(r#""{}""#, Self::escape_any(v, &*SLASHES)),
+            Text(v) => format!(r#""{}""#, Self::escape_any(v, &*QUOTES_SLASHES)),
         }
     }
 
@@ -117,7 +117,7 @@ mod test {
         assert_eq!(FieldValue(&Type::Text("\"".into())).escape(), r#""\"""#);
         assert_eq!(
             FieldValue(&Type::Text(r#"locat"\ ,=ion"#.into())).escape(),
-            r#""locat\"\\\ \,\=ion""#
+            r#""locat\"\\ ,=ion""#
         );
     }
 

--- a/influxdb/src/query/line_proto_term.rs
+++ b/influxdb/src/query/line_proto_term.rs
@@ -59,9 +59,9 @@ impl LineProtoTerm<'_> {
                 }
             }
             .to_string(),
-            Float(v) => format!(r#""{}""#, v.to_string()),
-            SignedInteger(v) => format!(r#""{}""#, v),
-            UnsignedInteger(v) => format!(r#""{}""#, v),
+            Float(v) => format!(r#"{}"#, v),
+            SignedInteger(v) => format!(r#"{}"#, v),
+            UnsignedInteger(v) => format!(r#"{}"#, v),
             Text(v) => Self::escape_any(v, &*SLASHES),
         }
     }
@@ -78,6 +78,11 @@ mod test {
 
     #[test]
     fn test() {
+        assert_eq!(TagValue(&Type::Boolean(true)).escape(), r#"true"#);
+        assert_eq!(TagValue(&Type::Float(1.8324f64)).escape(), r#"1.8324"#);
+        assert_eq!(TagValue(&Type::SignedInteger(-1i64)).escape(), r#"-1"#);
+        assert_eq!(TagValue(&Type::UnsignedInteger(1u64)).escape(), r#"1"#);
+
         assert_eq!(
             TagValue(&Type::Text("this is my special string".into())).escape(),
             r#"this\ is\ my\ special\ string"#

--- a/influxdb/tests/derive_integration_tests.rs
+++ b/influxdb/tests/derive_integration_tests.rs
@@ -35,7 +35,7 @@ fn test_build_query() {
         .unwrap();
     assert_eq!(
         query.get(),
-        "weather_reading,wind_strength=\"5\" humidity=30i 3600000000000"
+        "weather_reading,wind_strength=5 humidity=30i 3600000000000"
     );
 }
 


### PR DESCRIPTION
## Description

Fixes two issues related to quotation marks of tag values and improper escaping of field values.

1. Removed additional quotation marks for tag values with the type `Float`, `SignedInteger` and `UnsignedInteger`, otherwise they will be part of the string. (Removing the quotation marks for `Text` was already fixed in #64.)

[InfluxDB docs](https://docs.influxdata.com/influxdb/v1.8/write_protocols/line_protocol_tutorial/#quoting):
> Do not double or single quote measurement names, tag keys, tag values, and field keys. It is valid line protocol but InfluxDB assumes that the quotes are part of the name. 

2. Removed escaping of commas, equals and spaces for field values.

[InfluxDB docs](https://docs.influxdata.com/influxdb/v1.8/write_protocols/line_protocol_tutorial/#special-characters):
> For string field values use a backslash character `\` to escape:
  double quotes `"`


### Checklist
- [ ] Formatted code using `cargo fmt --all`
- [ ] Linted code using clippy `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Updated README.md using `cargo readme -r influxdb -t ../README.tpl > README.md`
- [ ] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [ ] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment