### PR TITLE
Add async-std support and replaced reqwest with surf (#58)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ use influxdb::{Client, Query, Timestamp};
 use influxdb::InfluxDbWriteable;
 use chrono::{DateTime, Utc};
 
-#[tokio::main]
+#[async_std::main]
 async fn main() {
     // Connect to db `test` on `http://localhost:8086`
     let client = Client::new("http://localhost:8086", "test");

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ use influxdb::InfluxDbWriteable;
 use chrono::{DateTime, Utc};
 
 #[async_std::main]
+// or #[tokio::main] if you prefer
 async fn main() {
     // Connect to db `test` on `http://localhost:8086`
     let client = Client::new("http://localhost:8086", "test");

--- a/influxdb/Cargo.toml
+++ b/influxdb/Cargo.toml
@@ -33,3 +33,4 @@ derive = ["influxdb_derive"]
 
 [dev-dependencies]
 async-std = { version = "1.6.5", features = ["attributes"] }
+tokio = { version =  "0.3.3", features = ["rt", "macros"] }

--- a/influxdb/Cargo.toml
+++ b/influxdb/Cargo.toml
@@ -21,7 +21,7 @@ futures = "0.3.4"
 lazy_static = "1.4.0"
 influxdb_derive = { version = "0.2.0", optional = true }
 regex = "1.3.5"
-reqwest = { version = "0.10.4", features = ["json"] }
+surf = { version = "2.1.0" }
 serde = { version = "1.0.104", features = ["derive"], optional = true }
 serde_json = { version = "1.0.48", optional = true }
 thiserror = "1.0"
@@ -32,4 +32,4 @@ default = ["use-serde"]
 derive = ["influxdb_derive"]
 
 [dev-dependencies]
-tokio = { version =  "0.2.11", features = ["macros"] }
+async-std = { version = "1.6.5", features = ["attributes"] }

--- a/influxdb/Cargo.toml
+++ b/influxdb/Cargo.toml
@@ -21,14 +21,18 @@ futures = "0.3.4"
 lazy_static = "1.4.0"
 influxdb_derive = { version = "0.2.0", optional = true }
 regex = "1.3.5"
-surf = { version = "2.1.0" }
+surf = { version = "2.1.0", default-features = false }
 serde = { version = "1.0.104", features = ["derive"], optional = true }
 serde_json = { version = "1.0.48", optional = true }
 thiserror = "1.0"
 
 [features]
 use-serde = ["serde", "serde_json"]
-default = ["use-serde"]
+curl-client = ["surf/curl-client"]
+h1-client = ["surf/h1-client"]
+hyper-client = ["surf/hyper-client"]
+wasm-client = ["surf/wasm-client"]
+default = ["use-serde", "hyper-client"]
 derive = ["influxdb_derive"]
 
 [dev-dependencies]

--- a/influxdb/src/client/mod.rs
+++ b/influxdb/src/client/mod.rs
@@ -16,7 +16,7 @@
 //! ```
 
 use futures::prelude::*;
-use surf::{self, Client as ReqwestClient, StatusCode, Url};
+use surf::{self, Client as SurfClient, StatusCode, Url};
 
 use crate::query::QueryTypes;
 use crate::Error;
@@ -203,9 +203,9 @@ impl Client {
                 url.query_pairs_mut().append_pair("q", &read_query);
 
                 if read_query.contains("SELECT") || read_query.contains("SHOW") {
-                    ReqwestClient::new().get(url)
+                    SurfClient::new().get(url)
                 } else {
-                    ReqwestClient::new().post(url)
+                    SurfClient::new().post(url)
                 }
             }
             QueryTypes::Write(write_query) => {
@@ -220,7 +220,7 @@ impl Client {
                 url.query_pairs_mut()
                     .append_pair("precision", &write_query.get_precision());
 
-                ReqwestClient::new().post(url).body(query.get())
+                SurfClient::new().post(url).body(query.get())
             }
         };
 

--- a/influxdb/src/error.rs
+++ b/influxdb/src/error.rs
@@ -34,8 +34,5 @@ pub enum Error {
 
     #[error("connection error: {error}")]
     /// Error happens when reqwest fails
-    ConnectionError {
-        #[from]
-        error: reqwest::Error,
-    },
+    ConnectionError { error: String },
 }

--- a/influxdb/src/error.rs
+++ b/influxdb/src/error.rs
@@ -33,6 +33,6 @@ pub enum Error {
     AuthorizationError,
 
     #[error("connection error: {error}")]
-    /// Error happens when reqwest fails
+    /// Error happens when HTTP request fails
     ConnectionError { error: String },
 }

--- a/influxdb/src/lib.rs
+++ b/influxdb/src/lib.rs
@@ -32,7 +32,7 @@
 //! use influxdb::InfluxDbWriteable;
 //! use chrono::{DateTime, Utc};
 //!
-//! #[tokio::main]
+//! #[async_std::main]
 //! async fn main() {
 //!     // Connect to db `test` on `http://localhost:8086`
 //!     let client = Client::new("http://localhost:8086", "test");

--- a/influxdb/src/lib.rs
+++ b/influxdb/src/lib.rs
@@ -33,6 +33,7 @@
 //! use chrono::{DateTime, Utc};
 //!
 //! #[async_std::main]
+//! // or #[tokio::main] if you prefer
 //! async fn main() {
 //!     // Connect to db `test` on `http://localhost:8086`
 //!     let client = Client::new("http://localhost:8086", "test");

--- a/influxdb/src/query/write_query.rs
+++ b/influxdb/src/query/write_query.rs
@@ -180,7 +180,7 @@ impl Query for WriteQuery {
             .join(",");
 
         if !tags.is_empty() {
-            tags.insert_str(0, ",");
+            tags.insert(0, ',');
         }
         let fields = self
             .fields

--- a/influxdb/tests/derive_integration_tests.rs
+++ b/influxdb/tests/derive_integration_tests.rs
@@ -43,7 +43,7 @@ fn test_build_query() {
 /// INTEGRATION TEST
 ///
 /// This integration tests that writing data and retrieving the data again is working
-#[tokio::test]
+#[async_std::test]
 async fn test_derive_simple_write() {
     const TEST_NAME: &str = "test_derive_simple_write";
 
@@ -72,7 +72,7 @@ async fn test_derive_simple_write() {
 /// This integration tests that writing data and retrieving the data again is working
 #[cfg(feature = "derive")]
 #[cfg(feature = "use-serde")]
-#[tokio::test]
+#[async_std::test]
 async fn test_write_and_read_option() {
     const TEST_NAME: &str = "test_write_and_read_option";
 

--- a/influxdb/tests/integration_tests.rs
+++ b/influxdb/tests/integration_tests.rs
@@ -11,9 +11,25 @@ use influxdb::{Client, Error, Query, Timestamp};
 
 /// INTEGRATION TEST
 ///
-/// This test case tests whether the InfluxDB server can be connected to and gathers info about it
+/// This test case tests whether the InfluxDB server can be connected to and gathers info about it - tested with async_std
 #[async_std::test]
-async fn test_ping_influx_db() {
+async fn test_ping_influx_db_async_std() {
+    let client = create_client("notusedhere");
+    let result = client.ping().await;
+    assert_result_ok(&result);
+
+    let (build, version) = result.unwrap();
+    assert!(!build.is_empty(), "Build should not be empty");
+    assert!(!version.is_empty(), "Build should not be empty");
+
+    println!("build: {} version: {}", build, version);
+}
+
+/// INTEGRATION TEST
+///
+/// This test case tests whether the InfluxDB server can be connected to and gathers info about it * tested with tokio
+#[tokio::test]
+async fn test_ping_influx_db_tokio() {
     let client = create_client("notusedhere");
     let result = client.ping().await;
     assert_result_ok(&result);
@@ -425,7 +441,8 @@ async fn test_json_query_tagged() {
 ///
 /// This test case tests whether JSON can be decoded from a InfluxDB response and wether that JSON
 /// is equal to the data which was written to the database
-#[async_std::test]
+/// (tested with tokio)
+#[tokio::test]
 #[cfg(feature = "use-serde")]
 async fn test_json_query_vec() {
     use serde::Deserialize;

--- a/influxdb/tests/integration_tests.rs
+++ b/influxdb/tests/integration_tests.rs
@@ -12,7 +12,7 @@ use influxdb::{Client, Error, Query, Timestamp};
 /// INTEGRATION TEST
 ///
 /// This test case tests whether the InfluxDB server can be connected to and gathers info about it
-#[tokio::test]
+#[async_std::test]
 async fn test_ping_influx_db() {
     let client = create_client("notusedhere");
     let result = client.ping().await;
@@ -28,7 +28,7 @@ async fn test_ping_influx_db() {
 /// INTEGRATION TEST
 ///
 /// This test case tests connection error
-#[tokio::test]
+#[async_std::test]
 async fn test_connection_error() {
     let test_name = "test_connection_error";
     let client =
@@ -48,7 +48,7 @@ async fn test_connection_error() {
 /// INTEGRATION TEST
 ///
 /// This test case tests the Authentication
-#[tokio::test]
+#[async_std::test]
 async fn test_authed_write_and_read() {
     const TEST_NAME: &str = "test_authed_write_and_read";
 
@@ -95,7 +95,7 @@ async fn test_authed_write_and_read() {
 /// INTEGRATION TEST
 ///
 /// This test case tests the Authentication
-#[tokio::test]
+#[async_std::test]
 async fn test_wrong_authed_write_and_read() {
     const TEST_NAME: &str = "test_wrong_authed_write_and_read";
 
@@ -164,7 +164,7 @@ async fn test_wrong_authed_write_and_read() {
 /// INTEGRATION TEST
 ///
 /// This test case tests the Authentication
-#[tokio::test]
+#[async_std::test]
 async fn test_non_authed_write_and_read() {
     const TEST_NAME: &str = "test_non_authed_write_and_read";
 
@@ -218,7 +218,7 @@ async fn test_non_authed_write_and_read() {
 /// INTEGRATION TEST
 ///
 /// This integration tests that writing data and retrieving the data again is working
-#[tokio::test]
+#[async_std::test]
 async fn test_write_and_read_field() {
     const TEST_NAME: &str = "test_write_field";
 
@@ -250,7 +250,7 @@ async fn test_write_and_read_field() {
 /// INTEGRATION TEST
 ///
 /// This integration tests that writing data and retrieving the data again is working
-#[tokio::test]
+#[async_std::test]
 #[cfg(feature = "use-serde")]
 async fn test_write_and_read_option() {
     use serde::Deserialize;
@@ -311,7 +311,7 @@ async fn test_write_and_read_option() {
 ///
 /// This test case tests whether JSON can be decoded from a InfluxDB response and whether that JSON
 /// is equal to the data which was written to the database
-#[tokio::test]
+#[async_std::test]
 #[cfg(feature = "use-serde")]
 async fn test_json_query() {
     use serde::Deserialize;
@@ -362,7 +362,7 @@ async fn test_json_query() {
 ///
 /// This test case tests whether the response to a GROUP BY can be parsed by
 // deserialize_next_tagged into a tags struct
-#[tokio::test]
+#[async_std::test]
 #[cfg(feature = "use-serde")]
 async fn test_json_query_tagged() {
     use serde::Deserialize;
@@ -425,7 +425,7 @@ async fn test_json_query_tagged() {
 ///
 /// This test case tests whether JSON can be decoded from a InfluxDB response and wether that JSON
 /// is equal to the data which was written to the database
-#[tokio::test]
+#[async_std::test]
 #[cfg(feature = "use-serde")]
 async fn test_json_query_vec() {
     use serde::Deserialize;
@@ -475,7 +475,7 @@ async fn test_json_query_vec() {
 /// INTEGRATION TEST
 ///
 /// This integration test tests whether using the wrong query method fails building the query
-#[tokio::test]
+#[async_std::test]
 #[cfg(feature = "use-serde")]
 async fn test_serde_multi_query() {
     use serde::Deserialize;
@@ -551,7 +551,7 @@ async fn test_serde_multi_query() {
 /// INTEGRATION TEST
 ///
 /// This integration test tests whether using the wrong query method fails building the query
-#[tokio::test]
+#[async_std::test]
 #[cfg(feature = "use-serde")]
 async fn test_wrong_query_errors() {
     let client = create_client("test_name");


### PR DESCRIPTION
## Description

This PR replaces [reqwest](https://crates.io/crates/reqwest) usage with [surf](https://crates.io/crates/surf) usage that supports both `tokio` and `async-std`. It also modifies the tests to run with both.
Fixes #58. 

### Checklist
- [x] Formatted code using `cargo fmt --all`
- [x] Linted code using clippy `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Updated README.md using `cargo readme -r influxdb -t ../README.tpl > README.md`
- [x] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [x] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment