### PR TITLE
CI: test against MSRV

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                rust_release: [1.41, stable, nightly]
+                rust_release: [1.42, stable, nightly]
                 os: [ubuntu-latest, windows-latest, macOS-latest]
 
         steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,23 +12,18 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v1
-            - uses: actions-rs/toolchain@v1
-              with:
-                toolchain: nightly
-                override: true
+            - uses: dtolnay/rust-toolchain@nightly
             - run: bash ./auxiliary/update_cargo-readme.sh
             - run: bash ./auxiliary/check_readme_consistency.sh
 
     style:
         name: Style Checks (stable/ubuntu-latest)
         runs-on: ubuntu-latest
-
         steps:
-            - uses: actions/checkout@master
-            - uses: hecrj/setup-rust-action@v1
+            - uses: actions/checkout@v1
+            - uses: dtolnay/rust-toolchain@nightly
               with:
                   components: "rustfmt,clippy"
-            - uses: actions/checkout@v1
             - name: Check code formatting
               run: cargo fmt --all -- --check
             - name: Check Clippy lints
@@ -39,14 +34,14 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                rust_release: [nightly, stable]
+                rust_release: [1.39, stable, nightly]
                 os: [ubuntu-latest, windows-latest, macOS-latest]
 
         steps:
-            - uses: actions/checkout@master
-            - uses: hecrj/setup-rust-action@v1
+            - uses: actions/checkout@v1
+            - uses: dtolnay/rust-toolchain@master
               with:
-                  rust-version: ${{ matrix.rust_release }}
+                  toolchain: ${{ matrix.rust_release }}
             - name: Build
               run: cargo build --verbose
 
@@ -71,11 +66,5 @@ jobs:
 
         steps:
             - uses: actions/checkout@v1
-            - uses: actions-rs/toolchain@v1
-              with:
-                toolchain: nightly
-                override: true
-            - uses: actions-rs/cargo@v1
-              with:
-                command: test
-                args: --package influxdb --package influxdb_derive --all-features --no-fail-fast
+            - uses: dtolnay/rust-toolchain@nightly
+            - run: cargo test --package influxdb --package influxdb_derive --all-features --no-fail-fast

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                rust_release: [1.42, stable, nightly]
+                rust_release: [1.45, stable, nightly]
                 os: [ubuntu-latest, windows-latest, macOS-latest]
 
         steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                rust_release: [1.39, stable, nightly]
+                rust_release: [1.41, stable, nightly]
                 os: [ubuntu-latest, windows-latest, macOS-latest]
 
         steps:

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@
     <a href="https://www.rust-lang.org/en-US/">
         <img src="https://img.shields.io/badge/Made%20with-Rust-orange.svg" alt='Build with Rust' />
     </a>
-    <a href="https://blog.rust-lang.org/2020/01/30/Rust-1.41.0.html">
-        <img src="https://img.shields.io/badge/rustc-1.41+-yellow.svg" alt='Minimum Rust Version' />
+    <a href="https://blog.rust-lang.org/2020/03/12/Rust-1.42.html">
+        <img src="https://img.shields.io/badge/rustc-1.42+-yellow.svg" alt='Minimum Rust Version' />
     </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@
     <a href="https://www.rust-lang.org/en-US/">
         <img src="https://img.shields.io/badge/Made%20with-Rust-orange.svg" alt='Build with Rust' />
     </a>
-    <a href="https://blog.rust-lang.org/2019/11/07/Rust-1.39.0.html">
-        <img src="https://img.shields.io/badge/rustc-1.39+-yellow.svg" alt='Minimum Rust Version' />
+    <a href="https://blog.rust-lang.org/2020/01/30/Rust-1.41.0.html">
+        <img src="https://img.shields.io/badge/rustc-1.41+-yellow.svg" alt='Minimum Rust Version' />
     </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@
     <a href="https://www.rust-lang.org/en-US/">
         <img src="https://img.shields.io/badge/Made%20with-Rust-orange.svg" alt='Build with Rust' />
     </a>
-    <a href="https://blog.rust-lang.org/2020/03/12/Rust-1.42.html">
-        <img src="https://img.shields.io/badge/rustc-1.42+-yellow.svg" alt='Minimum Rust Version' />
+    <a href="https://blog.rust-lang.org/2020/03/12/Rust-1.45.html">
+        <img src="https://img.shields.io/badge/rustc-1.45+-yellow.svg" alt='Minimum Rust Version' />
     </a>
 </p>
 

--- a/README.tpl
+++ b/README.tpl
@@ -22,8 +22,8 @@
     <a href="https://www.rust-lang.org/en-US/">
         <img src="https://img.shields.io/badge/Made%20with-Rust-orange.svg" alt='Build with Rust' />
     </a>
-    <a href="https://blog.rust-lang.org/2020/01/30/Rust-1.41.0.html">
-        <img src="https://img.shields.io/badge/rustc-1.41+-yellow.svg" alt='Minimum Rust Version' />
+    <a href="https://blog.rust-lang.org/2020/03/12/Rust-1.42.html">
+        <img src="https://img.shields.io/badge/rustc-1.42+-yellow.svg" alt='Minimum Rust Version' />
     </a>
 </p>
 

--- a/README.tpl
+++ b/README.tpl
@@ -22,8 +22,8 @@
     <a href="https://www.rust-lang.org/en-US/">
         <img src="https://img.shields.io/badge/Made%20with-Rust-orange.svg" alt='Build with Rust' />
     </a>
-    <a href="https://blog.rust-lang.org/2019/11/07/Rust-1.39.0.html">
-        <img src="https://img.shields.io/badge/rustc-1.39+-yellow.svg" alt='Minimum Rust Version' />
+    <a href="https://blog.rust-lang.org/2020/01/30/Rust-1.41.0.html">
+        <img src="https://img.shields.io/badge/rustc-1.41+-yellow.svg" alt='Minimum Rust Version' />
     </a>
 </p>
 

--- a/README.tpl
+++ b/README.tpl
@@ -22,8 +22,8 @@
     <a href="https://www.rust-lang.org/en-US/">
         <img src="https://img.shields.io/badge/Made%20with-Rust-orange.svg" alt='Build with Rust' />
     </a>
-    <a href="https://blog.rust-lang.org/2020/03/12/Rust-1.42.html">
-        <img src="https://img.shields.io/badge/rustc-1.42+-yellow.svg" alt='Minimum Rust Version' />
+    <a href="https://blog.rust-lang.org/2020/03/12/Rust-1.45.html">
+        <img src="https://img.shields.io/badge/rustc-1.45+-yellow.svg" alt='Minimum Rust Version' />
     </a>
 </p>
 

--- a/influxdb_derive/src/lib.rs
+++ b/influxdb_derive/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate proc_macro;
-
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;


### PR DESCRIPTION
## Description

- Bump the MSRV to 1.45 so that all dependencies compile
- Test against the MSRV
- Other small improvements: Use the same github action to download rust and don't run `actions/checkout` multiple times

### Checklist
- **N/A** Formatted code using `cargo fmt --all`
- **N/A** Linted code using clippy `cargo clippy --all-targets --all-features -- -D warnings`
- ✅ Updated README.md using `cargo readme -r influxdb -t ../README.tpl > README.md`
- ✅ Reviewed the diff. Did you leave any print statements or unnecessary comments?
- **N/A** Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment