### PR TITLE
CI: make tarpaulin ignore test code

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -122,7 +122,6 @@ jobs:
                 --all-features \
                 --exclude-files 'derive/*' \
                 --exclude-files 'target/*' \
-                --exclude-files 'influxdb/test/*' \
                 --ignore-panics --ignore-tests \
                 --out Html --out Json
             env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -103,7 +103,7 @@ jobs:
           - uses: actions/cache@v2
             with:
               path: |
-                ~/.cargo/bin
+                ~/.cargo/bin/cargo-tarpaulin
                 ~/.cargo/git
                 ~/.cargo/registry
                 target
@@ -111,9 +111,8 @@ jobs:
           
           - name: Install Tarpaulin
             run: |
-              ls -lh ~/.cargo || true
-              ls -lh ~/.cargo/bin || true
-              cargo install cargo-tarpaulin --version ${{ steps.tarpaulin-version.outputs.VERSION }}
+              ls -lh ~/.cargo/bin
+              test -e ~/.cargo/bin/cargo-tarpaulin || cargo install cargo-tarpaulin --version ${{ steps.tarpaulin-version.outputs.VERSION }}
           
           - name: Run Tarpaulin coverage tests
             run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -118,13 +118,14 @@ jobs:
           - name: Run Tarpaulin coverage tests
             run: |
               cargo tarpaulin -v \
-              	--target-dir target/tarpaulin \
-              	--workspace \
-              	--all-features \
-              	--exclude-files 'derive/*' \
-              	--exclude-files 'target/*' \
-              	--ignore-panics --ignore-tests \
-              	--out Html --out Json
+                --target-dir target/tarpaulin \
+                --workspace \
+                --all-features \
+                --exclude-files 'derive/*' \
+                --exclude-files 'target/*' \
+                --exclude-files 'influxdb/test/*' \
+                --ignore-panics --ignore-tests \
+                --out Html --out Json
             env:
               RUST_BACKTRACE: 1
               RUST_LOG: info

--- a/influxdb/tests/derive_integration_tests.rs
+++ b/influxdb/tests/derive_integration_tests.rs
@@ -44,6 +44,7 @@ fn test_build_query() {
 ///
 /// This integration tests that writing data and retrieving the data again is working
 #[async_std::test]
+#[cfg(not(tarpaulin_include))]
 async fn test_derive_simple_write() {
     const TEST_NAME: &str = "test_derive_simple_write";
 
@@ -73,6 +74,7 @@ async fn test_derive_simple_write() {
 #[cfg(feature = "derive")]
 #[cfg(feature = "use-serde")]
 #[async_std::test]
+#[cfg(not(tarpaulin_include))]
 async fn test_write_and_read_option() {
     const TEST_NAME: &str = "test_write_and_read_option";
 

--- a/influxdb/tests/integration_tests.rs
+++ b/influxdb/tests/integration_tests.rs
@@ -274,7 +274,8 @@ async fn test_write_and_read_field() {
 ///
 /// This integration tests that writing data and retrieving the data again is working
 #[async_std::test]
-#[cfg(all(feature = "use-serde", not(tarpaulin_include)))]
+#[cfg(feature = "use-serde")]
+#[cfg(not(tarpaulin_include))]
 async fn test_write_and_read_option() {
     use serde::Deserialize;
 
@@ -335,7 +336,8 @@ async fn test_write_and_read_option() {
 /// This test case tests whether JSON can be decoded from a InfluxDB response and whether that JSON
 /// is equal to the data which was written to the database
 #[async_std::test]
-#[cfg(all(feature = "use-serde", not(tarpaulin_include)))]
+#[cfg(feature = "use-serde")]
+#[cfg(not(tarpaulin_include))]
 async fn test_json_query() {
     use serde::Deserialize;
 
@@ -386,7 +388,8 @@ async fn test_json_query() {
 /// This test case tests whether the response to a GROUP BY can be parsed by
 // deserialize_next_tagged into a tags struct
 #[async_std::test]
-#[cfg(all(feature = "use-serde", not(tarpaulin_include)))]
+#[cfg(feature = "use-serde")]
+#[cfg(not(tarpaulin_include))]
 async fn test_json_query_tagged() {
     use serde::Deserialize;
 
@@ -450,7 +453,8 @@ async fn test_json_query_tagged() {
 /// is equal to the data which was written to the database
 /// (tested with tokio)
 #[tokio::test]
-#[cfg(all(feature = "use-serde", not(tarpaulin_include)))]
+#[cfg(feature = "use-serde")]
+#[cfg(not(tarpaulin_include))]
 async fn test_json_query_vec() {
     use serde::Deserialize;
 
@@ -500,7 +504,8 @@ async fn test_json_query_vec() {
 ///
 /// This integration test tests whether using the wrong query method fails building the query
 #[async_std::test]
-#[cfg(all(feature = "use-serde", not(tarpaulin_include)))]
+#[cfg(feature = "use-serde")]
+#[cfg(not(tarpaulin_include))]
 async fn test_serde_multi_query() {
     use serde::Deserialize;
 
@@ -576,7 +581,8 @@ async fn test_serde_multi_query() {
 ///
 /// This integration test tests whether using the wrong query method fails building the query
 #[async_std::test]
-#[cfg(all(feature = "use-serde", not(tarpaulin_include)))]
+#[cfg(feature = "use-serde")]
+#[cfg(not(tarpaulin_include))]
 async fn test_wrong_query_errors() {
     let client = create_client("test_name");
     let result = client

--- a/influxdb/tests/integration_tests.rs
+++ b/influxdb/tests/integration_tests.rs
@@ -13,6 +13,7 @@ use influxdb::{Client, Error, Query, Timestamp};
 ///
 /// This test case tests whether the InfluxDB server can be connected to and gathers info about it - tested with async_std
 #[async_std::test]
+#[cfg(not(tarpaulin_include))]
 async fn test_ping_influx_db_async_std() {
     let client = create_client("notusedhere");
     let result = client.ping().await;
@@ -29,6 +30,7 @@ async fn test_ping_influx_db_async_std() {
 ///
 /// This test case tests whether the InfluxDB server can be connected to and gathers info about it * tested with tokio
 #[tokio::test]
+#[cfg(not(tarpaulin_include))]
 async fn test_ping_influx_db_tokio() {
     let client = create_client("notusedhere");
     let result = client.ping().await;
@@ -45,6 +47,7 @@ async fn test_ping_influx_db_tokio() {
 ///
 /// This test case tests connection error
 #[async_std::test]
+#[cfg(not(tarpaulin_include))]
 async fn test_connection_error() {
     let test_name = "test_connection_error";
     let client =
@@ -65,6 +68,7 @@ async fn test_connection_error() {
 ///
 /// This test case tests the Authentication
 #[async_std::test]
+#[cfg(not(tarpaulin_include))]
 async fn test_authed_write_and_read() {
     const TEST_NAME: &str = "test_authed_write_and_read";
 
@@ -112,6 +116,7 @@ async fn test_authed_write_and_read() {
 ///
 /// This test case tests the Authentication
 #[async_std::test]
+#[cfg(not(tarpaulin_include))]
 async fn test_wrong_authed_write_and_read() {
     const TEST_NAME: &str = "test_wrong_authed_write_and_read";
 
@@ -181,6 +186,7 @@ async fn test_wrong_authed_write_and_read() {
 ///
 /// This test case tests the Authentication
 #[async_std::test]
+#[cfg(not(tarpaulin_include))]
 async fn test_non_authed_write_and_read() {
     const TEST_NAME: &str = "test_non_authed_write_and_read";
 
@@ -235,6 +241,7 @@ async fn test_non_authed_write_and_read() {
 ///
 /// This integration tests that writing data and retrieving the data again is working
 #[async_std::test]
+#[cfg(not(tarpaulin_include))]
 async fn test_write_and_read_field() {
     const TEST_NAME: &str = "test_write_field";
 
@@ -267,7 +274,7 @@ async fn test_write_and_read_field() {
 ///
 /// This integration tests that writing data and retrieving the data again is working
 #[async_std::test]
-#[cfg(feature = "use-serde")]
+#[cfg(all(feature = "use-serde", not(tarpaulin_include)))]
 async fn test_write_and_read_option() {
     use serde::Deserialize;
 
@@ -328,7 +335,7 @@ async fn test_write_and_read_option() {
 /// This test case tests whether JSON can be decoded from a InfluxDB response and whether that JSON
 /// is equal to the data which was written to the database
 #[async_std::test]
-#[cfg(feature = "use-serde")]
+#[cfg(all(feature = "use-serde", not(tarpaulin_include)))]
 async fn test_json_query() {
     use serde::Deserialize;
 
@@ -379,7 +386,7 @@ async fn test_json_query() {
 /// This test case tests whether the response to a GROUP BY can be parsed by
 // deserialize_next_tagged into a tags struct
 #[async_std::test]
-#[cfg(feature = "use-serde")]
+#[cfg(all(feature = "use-serde", not(tarpaulin_include)))]
 async fn test_json_query_tagged() {
     use serde::Deserialize;
 
@@ -443,7 +450,7 @@ async fn test_json_query_tagged() {
 /// is equal to the data which was written to the database
 /// (tested with tokio)
 #[tokio::test]
-#[cfg(feature = "use-serde")]
+#[cfg(all(feature = "use-serde", not(tarpaulin_include)))]
 async fn test_json_query_vec() {
     use serde::Deserialize;
 
@@ -493,7 +500,7 @@ async fn test_json_query_vec() {
 ///
 /// This integration test tests whether using the wrong query method fails building the query
 #[async_std::test]
-#[cfg(feature = "use-serde")]
+#[cfg(all(feature = "use-serde", not(tarpaulin_include)))]
 async fn test_serde_multi_query() {
     use serde::Deserialize;
 
@@ -569,7 +576,7 @@ async fn test_serde_multi_query() {
 ///
 /// This integration test tests whether using the wrong query method fails building the query
 #[async_std::test]
-#[cfg(feature = "use-serde")]
+#[cfg(all(feature = "use-serde", not(tarpaulin_include)))]
 async fn test_wrong_query_errors() {
     let client = create_client("test_name");
     let result = client

--- a/influxdb/tests/utilities.rs
+++ b/influxdb/tests/utilities.rs
@@ -3,14 +3,17 @@ use influxdb::{Client, Error, Query};
 use std::panic::{AssertUnwindSafe, UnwindSafe};
 
 #[allow(dead_code)]
+#[cfg(not(tarpaulin_include))]
 pub fn assert_result_err<A: std::fmt::Debug, B: std::fmt::Debug>(result: &Result<A, B>) {
     result.as_ref().expect_err("assert_result_err failed");
 }
 
+#[cfg(not(tarpaulin_include))]
 pub fn assert_result_ok<A: std::fmt::Debug, B: std::fmt::Debug>(result: &Result<A, B>) {
     result.as_ref().expect("assert_result_ok failed");
 }
 
+#[cfg(not(tarpaulin_include))]
 pub fn create_client<T>(db_name: T) -> Client
 where
     T: Into<String>,
@@ -18,6 +21,7 @@ where
     Client::new("http://localhost:8086", db_name)
 }
 
+#[cfg(not(tarpaulin_include))]
 pub async fn create_db<T>(name: T) -> Result<String, Error>
 where
     T: Into<String>,
@@ -29,6 +33,7 @@ where
         .await
 }
 
+#[cfg(not(tarpaulin_include))]
 pub async fn delete_db<T>(name: T) -> Result<String, Error>
 where
     T: Into<String>,
@@ -40,6 +45,7 @@ where
         .await
 }
 
+#[cfg(not(tarpaulin_include))]
 pub async fn run_test<F, T, Fut1, Fut2>(test_fn: F, teardown: T)
 where
     F: FnOnce() -> Fut1 + UnwindSafe,


### PR DESCRIPTION
## Description

tarpaulin does not recognize the `tests/` folder, `async_std::test` or `tokio::test`, so we'll ignore that code manually

also fixes a caching issue with GitHub actions

### Checklist
- [ ] Formatted code using `cargo fmt --all`
- [ ] Linted code using clippy `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Updated README.md using `cargo readme -r influxdb -t ../README.tpl > README.md`
- [ ] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [ ] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment