### PR TITLE
influxdb-derive: add #[ignored] attribute

### DIFF
--- a/influxdb/tests/derive_integration_tests.rs
+++ b/influxdb/tests/derive_integration_tests.rs
@@ -22,6 +22,18 @@ struct WeatherReading {
     wind_strength: Option<u64>,
 }
 
+#[derive(Debug, PartialEq)]
+#[cfg_attr(feature = "derive", derive(InfluxDbWriteable))]
+#[cfg_attr(feature = "use-serde", derive(Deserialize))]
+struct WeatherReadingIgnoredField {
+    time: DateTime<Utc>,
+    humidity: i32,
+    #[tag]
+    wind_strength: Option<u64>,
+    #[ignored]
+    temperature: u64,
+}
+
 #[test]
 fn test_build_query() {
     let weather_reading = WeatherReading {
@@ -80,10 +92,11 @@ async fn test_write_and_read_option() {
         || async move {
             create_db(TEST_NAME).await.expect("could not setup db");
             let client = create_client(TEST_NAME);
-            let weather_reading = WeatherReading {
+            let weather_reading = WeatherReadingIgnoredField {
                 time: Timestamp::Hours(11).into(),
                 humidity: 30,
                 wind_strength: None,
+                temperature: 11,
             };
             let write_result = client
                 .query(&weather_reading.into_query("weather_reading".to_string()))

--- a/influxdb_derive/src/lib.rs
+++ b/influxdb_derive/src/lib.rs
@@ -9,7 +9,7 @@ fn krate() -> TokenStream2 {
     quote!(::influxdb)
 }
 
-#[proc_macro_derive(InfluxDbWriteable, attributes(tag))]
+#[proc_macro_derive(InfluxDbWriteable, attributes(tag, ignored))]
 pub fn derive_writeable(tokens: TokenStream) -> TokenStream {
     expand_writeable(tokens)
 }


### PR DESCRIPTION
This attribute signals influx to avoid inserting a field

ref: #76 
## Description

{ describe your changes here }

### Checklist
- [x ] Formatted code using `cargo fmt --all`
- [ x] Linted code using clippy `cargo clippy --all-targets --all-features -- -D warnings`
- [ x] Updated README.md using `cargo readme -r influxdb -t ../README.tpl > README.md`
- [ x] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [ x] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment