### PR TITLE
Assertion should consider case-insensitive keywords

### DIFF
--- a/influxdb/src/integrations/serde_integration/mod.rs
+++ b/influxdb/src/integrations/serde_integration/mod.rs
@@ -129,8 +129,9 @@ impl Client {
         })?;
 
         let read_query = query.get();
+        let read_query_lower = read_query.to_lowercase();
 
-        if !read_query.contains("SELECT") && !read_query.contains("SHOW") {
+        if !read_query_lower.contains("select") && !read_query_lower.contains("show") {
             let error = Error::InvalidQueryError {
                 error: String::from(
                     "Only SELECT and SHOW queries supported with JSON deserialization",


### PR DESCRIPTION
## Description

Consider case-insensitive keywords in `serde_integration` assertion. 

### Checklist
- [x] Formatted code using `cargo fmt --all`
- [x] Linted code using clippy `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Updated README.md using `cargo readme -r influxdb -t ../README.tpl > README.md`
- [x] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [x] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment