### PR TITLE
Add h1-client-rustls feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,7 +50,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                http-backend: [curl-client, h1-client, h1-client-rustls, hyper-client, wasm-client]
+                http-backend: [curl-client, h1-client, h1-client-rustls, hyper-client]
         services:
             influxdb:
                 image: influxdb:1.8

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,6 +48,9 @@ jobs:
     integration_test:
         name: Integration Tests (stable/ubuntu-latest)
         runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                http-backend: [curl-client, h1-client, h1-client-rustls, hyper-client, wasm-client]
         services:
             influxdb:
                 image: influxdb:1.8
@@ -67,7 +70,7 @@ jobs:
         steps:
             - uses: actions/checkout@v1
             - uses: dtolnay/rust-toolchain@stable
-            - run: cargo test --package influxdb --package influxdb_derive --all-features --no-fail-fast
+            - run: cargo test --manifest-path=./influxdb/Cargo.toml --no-default-features --features 'use-serde derive ${{ matrix.http-backend }}' --no-fail-fast
 
     coverage:
         name: Code Coverage (stable/ubuntu-20.04)

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ To communicate with InfluxDB, you can choose the HTTP backend to be used configu
    ```toml
    influxdb = { version = "0.3.0", default-features = false, features = ["derive", "use-serde", "h1-client"] }
    ```
-- **[async-h1](https://github.com/http-rs/async-h1)** with [rutstls](https://github.com/ctz/rustls)
+- **[async-h1](https://github.com/http-rs/async-h1)** with [rustls](https://github.com/ctz/rustls)
    ```toml
    influxdb = { version = "0.3.0", default-features = false, features = ["derive", "use-serde", "h1-client-rustls"] }
    ```

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Pull requests are always welcome. See [Contributing](https://github.com/Empty2k1
 -   `#[derive(InfluxDbWriteable)]` Derive Macro for Writing / Reading into Structs
 -   `GROUP BY` support
 -   Tokio and async-std support (see example below) or [available backends](https://github.com/Empty2k12/influxdb-rust/blob/master/influxdb/Cargo.toml)
+-   Swappable HTTP backends ([see below](#Choice-of-HTTP-backend))
 
 ## Quickstart
 
@@ -97,6 +98,31 @@ async fn main() {
 
 For further examples, check out the Integration Tests in `tests/integration_tests.rs`
 in the repository.
+
+## Choice of HTTP backend
+
+To communicate with InfluxDB, you can choose the HTTP backend to be used configuring the appropriate feature:
+
+- **[hyper](https://github.com/hyperium/hyper)** (used by default)
+   ```toml
+   influxdb = { version = "0.3.0", features = ["derive"] }
+   ```
+- **[curl](https://github.com/alexcrichton/curl-rust)**, using [libcurl](https://curl.se/libcurl/)
+   ```toml
+   influxdb = { version = "0.3.0", default-features = false, features = ["derive", "use-serde", "curl-client"] }
+   ```
+- **[async-h1](https://github.com/http-rs/async-h1)** with native TLS (OpenSSL)
+   ```toml
+   influxdb = { version = "0.3.0", default-features = false, features = ["derive", "use-serde", "h1-client"] }
+   ```
+- **[async-h1](https://github.com/http-rs/async-h1)** with [rutstls](https://github.com/ctz/rustls)
+   ```toml
+   influxdb = { version = "0.3.0", default-features = false, features = ["derive", "use-serde", "h1-client-rustls"] }
+   ```
+- WebAssembly's `window.fetch`, via `web-sys` and **[wasm-bindgen](https://github.com/rustwasm/wasm-bindgen)**
+   ```toml
+   influxdb = { version = "0.3.0", default-features = false, features = ["derive", "use-serde", "wasm-client"] }
+   ```
 
 ## License
 

--- a/influxdb/Cargo.toml
+++ b/influxdb/Cargo.toml
@@ -21,7 +21,7 @@ futures = "0.3.4"
 lazy_static = "1.4.0"
 influxdb_derive = { version = "0.3.0", optional = true }
 regex = "1.3.5"
-surf = { version = "2.1.0", default-features = false }
+surf = { version = "2.2.0", default-features = false }
 serde = { version = "1.0.104", features = ["derive"], optional = true }
 serde_json = { version = "1.0.48", optional = true }
 thiserror = "1.0"
@@ -30,6 +30,7 @@ thiserror = "1.0"
 use-serde = ["serde", "serde_json"]
 curl-client = ["surf/curl-client"]
 h1-client = ["surf/h1-client"]
+h1-client-rustls = ["surf/h1-client-rustls"]
 hyper-client = ["surf/hyper-client"]
 wasm-client = ["surf/wasm-client"]
 default = ["use-serde", "hyper-client"]

--- a/influxdb/src/lib.rs
+++ b/influxdb/src/lib.rs
@@ -13,6 +13,7 @@
 //! -   `#[derive(InfluxDbWriteable)]` Derive Macro for Writing / Reading into Structs
 //! -   `GROUP BY` support
 //! -   Tokio and async-std support (see example below) or [available backends](https://github.com/Empty2k12/influxdb-rust/blob/master/influxdb/Cargo.toml)
+//! -   Swappable HTTP backends ([see below](#Choice-of-HTTP-backend))
 //!
 //! # Quickstart
 //!
@@ -65,6 +66,31 @@
 //!
 //! For further examples, check out the Integration Tests in `tests/integration_tests.rs`
 //! in the repository.
+//!
+//! # Choice of HTTP backend
+//!
+//! To communicate with InfluxDB, you can choose the HTTP backend to be used configuring the appropriate feature:
+//!
+//! - **[hyper](https://github.com/hyperium/hyper)** (used by default)
+//!    ```toml
+//!    influxdb = { version = "0.3.0", features = ["derive"] }
+//!    ```
+//! - **[curl](https://github.com/alexcrichton/curl-rust)**, using [libcurl](https://curl.se/libcurl/)
+//!    ```toml
+//!    influxdb = { version = "0.3.0", default-features = false, features = ["derive", "use-serde", "curl-client"] }
+//!    ```
+//! - **[async-h1](https://github.com/http-rs/async-h1)** with native TLS (OpenSSL)
+//!    ```toml
+//!    influxdb = { version = "0.3.0", default-features = false, features = ["derive", "use-serde", "h1-client"] }
+//!    ```
+//! - **[async-h1](https://github.com/http-rs/async-h1)** with [rutstls](https://github.com/ctz/rustls)
+//!    ```toml
+//!    influxdb = { version = "0.3.0", default-features = false, features = ["derive", "use-serde", "h1-client-rustls"] }
+//!    ```
+//! - WebAssembly's `window.fetch`, via `web-sys` and **[wasm-bindgen](https://github.com/rustwasm/wasm-bindgen)**
+//!    ```toml
+//!    influxdb = { version = "0.3.0", default-features = false, features = ["derive", "use-serde", "wasm-client"] }
+//!    ```
 //!
 //! # License
 //!

--- a/influxdb/src/lib.rs
+++ b/influxdb/src/lib.rs
@@ -83,7 +83,7 @@
 //!    ```toml
 //!    influxdb = { version = "0.3.0", default-features = false, features = ["derive", "use-serde", "h1-client"] }
 //!    ```
-//! - **[async-h1](https://github.com/http-rs/async-h1)** with [rutstls](https://github.com/ctz/rustls)
+//! - **[async-h1](https://github.com/http-rs/async-h1)** with [rustls](https://github.com/ctz/rustls)
 //!    ```toml
 //!    influxdb = { version = "0.3.0", default-features = false, features = ["derive", "use-serde", "h1-client-rustls"] }
 //!    ```

--- a/influxdb/tests/integration_tests.rs
+++ b/influxdb/tests/integration_tests.rs
@@ -51,7 +51,7 @@ async fn test_ping_influx_db_tokio() {
 async fn test_connection_error() {
     let test_name = "test_connection_error";
     let client =
-        Client::new("http://localhost:10086", test_name).with_auth("nopriv_user", "password");
+        Client::new("http://127.0.0.1:10086", test_name).with_auth("nopriv_user", "password");
     let read_query = Query::raw_read_query("SELECT * FROM weather");
     let read_result = client.query(&read_query).await;
     assert_result_err(&read_result);
@@ -75,7 +75,7 @@ async fn test_authed_write_and_read() {
     run_test(
         || async move {
             let client =
-                Client::new("http://localhost:9086", TEST_NAME).with_auth("admin", "password");
+                Client::new("http://127.0.0.1:9086", TEST_NAME).with_auth("admin", "password");
             let query = format!("CREATE DATABASE {}", TEST_NAME);
             client
                 .query(&Query::raw_read_query(query))
@@ -83,7 +83,7 @@ async fn test_authed_write_and_read() {
                 .expect("could not setup db");
 
             let client =
-                Client::new("http://localhost:9086", TEST_NAME).with_auth("admin", "password");
+                Client::new("http://127.0.0.1:9086", TEST_NAME).with_auth("admin", "password");
             let write_query = Timestamp::Hours(11)
                 .into_query("weather")
                 .add_field("temperature", 82);
@@ -100,7 +100,7 @@ async fn test_authed_write_and_read() {
         },
         || async move {
             let client =
-                Client::new("http://localhost:9086", TEST_NAME).with_auth("admin", "password");
+                Client::new("http://127.0.0.1:9086", TEST_NAME).with_auth("admin", "password");
             let query = format!("DROP DATABASE {}", TEST_NAME);
 
             client
@@ -123,7 +123,7 @@ async fn test_wrong_authed_write_and_read() {
     run_test(
         || async move {
             let client =
-                Client::new("http://localhost:9086", TEST_NAME).with_auth("admin", "password");
+                Client::new("http://127.0.0.1:9086", TEST_NAME).with_auth("admin", "password");
             let query = format!("CREATE DATABASE {}", TEST_NAME);
             client
                 .query(&Query::raw_read_query(query))
@@ -131,7 +131,7 @@ async fn test_wrong_authed_write_and_read() {
                 .expect("could not setup db");
 
             let client =
-                Client::new("http://localhost:9086", TEST_NAME).with_auth("wrong_user", "password");
+                Client::new("http://127.0.0.1:9086", TEST_NAME).with_auth("wrong_user", "password");
             let write_query = Timestamp::Hours(11)
                 .into_query("weather")
                 .add_field("temperature", 82);
@@ -156,7 +156,7 @@ async fn test_wrong_authed_write_and_read() {
                 ),
             }
 
-            let client = Client::new("http://localhost:9086", TEST_NAME)
+            let client = Client::new("http://127.0.0.1:9086", TEST_NAME)
                 .with_auth("nopriv_user", "password");
             let read_query = Query::raw_read_query("SELECT * FROM weather");
             let read_result = client.query(&read_query).await;
@@ -171,7 +171,7 @@ async fn test_wrong_authed_write_and_read() {
         },
         || async move {
             let client =
-                Client::new("http://localhost:9086", TEST_NAME).with_auth("admin", "password");
+                Client::new("http://127.0.0.1:9086", TEST_NAME).with_auth("admin", "password");
             let query = format!("DROP DATABASE {}", TEST_NAME);
             client
                 .query(&Query::raw_read_query(query))
@@ -193,13 +193,13 @@ async fn test_non_authed_write_and_read() {
     run_test(
         || async move {
             let client =
-                Client::new("http://localhost:9086", TEST_NAME).with_auth("admin", "password");
+                Client::new("http://127.0.0.1:9086", TEST_NAME).with_auth("admin", "password");
             let query = format!("CREATE DATABASE {}", TEST_NAME);
             client
                 .query(&Query::raw_read_query(query))
                 .await
                 .expect("could not setup db");
-            let non_authed_client = Client::new("http://localhost:9086", TEST_NAME);
+            let non_authed_client = Client::new("http://127.0.0.1:9086", TEST_NAME);
             let write_query = Timestamp::Hours(11)
                 .into_query("weather")
                 .add_field("temperature", 82);
@@ -226,7 +226,7 @@ async fn test_non_authed_write_and_read() {
         },
         || async move {
             let client =
-                Client::new("http://localhost:9086", TEST_NAME).with_auth("admin", "password");
+                Client::new("http://127.0.0.1:9086", TEST_NAME).with_auth("admin", "password");
             let query = format!("DROP DATABASE {}", TEST_NAME);
             client
                 .query(&Query::raw_read_query(query))

--- a/influxdb/tests/utilities.rs
+++ b/influxdb/tests/utilities.rs
@@ -18,7 +18,7 @@ pub fn create_client<T>(db_name: T) -> Client
 where
     T: Into<String>,
 {
-    Client::new("http://localhost:8086", db_name)
+    Client::new("http://127.0.0.1:8086", db_name)
 }
 
 #[cfg(not(tarpaulin_include))]


### PR DESCRIPTION
## Description

- Add a `h1-client-rustls`feature, allowing to use [rustls](https://github.com/ctz/rustls) instead of OpenSSL for HTTPS (and thus being more portable to various platforms)
- Bump `surf` to 2.2.0 (to use `surf/h1-client-rustls` feature)
- Add `Choice of HTTP backend` section in README.md, describing the different features
- Update `rust.yml` workflow to test a matrix of HTTP backends, instead of using `--all-features` that activate all, but ends with only `curl-client` to be tested (as per [surf implementation](https://github.com/http-rs/surf/blob/1adb82125268371fa6eb224ac9c79cedd20dc9bb/src/client.rs#L11)) 


### Checklist
- [X] Formatted code using `cargo fmt --all`
- [X] Linted code using clippy `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Updated README.md using `cargo readme -r influxdb -t ../README.tpl > README.md`
- [X] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [X] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment