### PR TITLE
Reqwest Client (Tokio 1.0 support)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,7 +50,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                http-backend: [curl-client, h1-client, h1-client-rustls, hyper-client]
+                http-backend: [curl-client, h1-client, h1-client-rustls, hyper-client, reqwest-client, reqwest-client-rustls]
         services:
             influxdb:
                 image: influxdb:1.8

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,8 +25,10 @@ jobs:
                   components: "rustfmt,clippy"
             - name: Check code formatting
               run: cargo fmt --all -- --check
-            - name: Check Clippy lints
-              run: cargo clippy --all-targets --all-features -- -D warnings
+            - name: Check Clippy lints (reqwest)
+              run: cargo clippy --all-targets --no-default-features --features use-serde,derive,reqwest-client -- -D warnings
+            - name: Check Clippy lints (surf)
+              run: cargo clippy --all-targets --no-default-features --features use-serde,derive,hyper-client -- -D warnings
 
     compile:
         name: Compile (${{ matrix.rust_release }}/${{ matrix.os }})
@@ -121,7 +123,7 @@ jobs:
               cargo tarpaulin -v \
                 --target-dir target/tarpaulin \
                 --workspace \
-                --all-features \
+                --features use-serde,derive \
                 --exclude-files 'derive/*' \
                 --exclude-files 'target/*' \
                 --ignore-panics --ignore-tests \

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                rust_release: [1.45, stable, nightly]
+                rust_release: [1.46, stable, nightly]
                 os: [ubuntu-latest, windows-latest, macOS-latest]
 
         steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,6 +3,7 @@ name: Rust
 on:
   push:
     branches:
+      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,7 +3,6 @@ name: Rust
 on:
   push:
     branches:
-      - master
   pull_request:
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- reqwest-based http client (enabled by default)
+
 ## [0.4.0] - 2021-03-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@
     <a href="https://www.rust-lang.org/en-US/">
         <img src="https://img.shields.io/badge/Made%20with-Rust-orange.svg" alt='Build with Rust' />
     </a>
-    <a href="https://blog.rust-lang.org/2020/03/12/Rust-1.45.html">
-        <img src="https://img.shields.io/badge/rustc-1.45+-yellow.svg" alt='Minimum Rust Version' />
+    <a href="https://blog.rust-lang.org/2020/08/27/Rust-1.46.0.html">
+        <img src="https://img.shields.io/badge/rustc-1.46+-yellow.svg" alt='Minimum Rust Version' />
     </a>
 </p>
 
@@ -62,8 +62,8 @@ use influxdb::{Client, Query, Timestamp};
 use influxdb::InfluxDbWriteable;
 use chrono::{DateTime, Utc};
 
-#[async_std::main]
-// or #[tokio::main] if you prefer
+#[tokio::main]
+// or #[async_std::main] if you prefer
 async fn main() {
     // Connect to db `test` on `http://localhost:8086`
     let client = Client::new("http://localhost:8086", "test");
@@ -101,11 +101,21 @@ in the repository.
 
 ## Choice of HTTP backend
 
-To communicate with InfluxDB, you can choose the HTTP backend to be used configuring the appropriate feature:
+To communicate with InfluxDB, you can choose the HTTP backend to be used configuring the appropriate feature. We recommend sticking with the default reqwest-based client, unless you really need async-std compatibility.
 
-- **[hyper](https://github.com/hyperium/hyper)** (used by default)
+- **[hyper](https://github.com/hyperium/hyper)** (through reqwest, used by default), with [rustls](https://github.com/ctz/rustls)
+  ```toml
+  influxdb = { version = "0.4.0", features = ["derive"] }
+  ```
+
+- **[hyper](https://github.com/hyperium/hyper)** (through reqwest), with native TLS (OpenSSL)
+  ```toml
+  influxdb = { version = "0.4.0", default-features = false, features = ["derive", "use-serde", "reqwest-client"] }
+  ```
+
+- **[hyper](https://github.com/hyperium/hyper)** (through surf), use this if you need tokio 0.2 compatibility
    ```toml
-   influxdb = { version = "0.4.0", features = ["derive"] }
+   influxdb = { version = "0.4.0", default-features = false, features = ["derive", "use-serde", "curl-client"] }
    ```
 - **[curl](https://github.com/alexcrichton/curl-rust)**, using [libcurl](https://curl.se/libcurl/)
    ```toml

--- a/README.tpl
+++ b/README.tpl
@@ -25,8 +25,8 @@
     <a href="https://www.rust-lang.org/en-US/">
         <img src="https://img.shields.io/badge/Made%20with-Rust-orange.svg" alt='Build with Rust' />
     </a>
-    <a href="https://blog.rust-lang.org/2020/03/12/Rust-1.45.html">
-        <img src="https://img.shields.io/badge/rustc-1.45+-yellow.svg" alt='Minimum Rust Version' />
+    <a href="https://blog.rust-lang.org/2020/08/27/Rust-1.46.0.html">
+        <img src="https://img.shields.io/badge/rustc-1.46+-yellow.svg" alt='Minimum Rust Version' />
     </a>
 </p>
 

--- a/influxdb/Cargo.toml
+++ b/influxdb/Cargo.toml
@@ -45,4 +45,4 @@ wasm-client = ["surf", "surf/wasm-client"]
 [dev-dependencies]
 async-std = { version = "1.6.5", features = ["attributes"] }
 tokio02 = { package = "tokio", version = "0.2.22", features = ["rt-threaded", "macros"] }
-tokio = { version = "1.7", features = ["rt"] }
+tokio = { version = "1.7", features = ["macros", "rt"] }

--- a/influxdb/Cargo.toml
+++ b/influxdb/Cargo.toml
@@ -43,6 +43,5 @@ reqwest-client-rustls = ["reqwest", "reqwest/rustls-tls-webpki-roots"]
 wasm-client = ["surf", "surf/wasm-client"]
 
 [dev-dependencies]
-async-std = { version = "1.6.5", features = ["attributes"] }
-tokio02 = { package = "tokio", version = "0.2.22", features = ["rt-threaded", "macros"] }
+async-std = { version = "1.6.5", features = ["attributes", "tokio02", "tokio1"] }
 tokio = { version = "1.7", features = ["macros", "rt-multi-thread"] }

--- a/influxdb/Cargo.toml
+++ b/influxdb/Cargo.toml
@@ -18,24 +18,31 @@ travis-ci = { repository = "Empty2k12/influxdb-rust", branch = "master" }
 [dependencies]
 chrono = { version = "0.4.11", features = ["serde"] }
 futures = "0.3.4"
-lazy_static = "1.4.0"
+http = "0.2.4"
 influxdb_derive = { version = "0.4.0", optional = true }
+lazy_static = "1.4.0"
 regex = "1.3.5"
-surf = { version = "2.2.0", default-features = false }
+reqwest = { version = "0.11.4", default-features = false, optional = true }
+surf = { version = "2.2.0", default-features = false, optional = true }
 serde = { version = "1.0.104", features = ["derive"], optional = true }
 serde_json = { version = "1.0.48", optional = true }
 thiserror = "1.0"
 
 [features]
-use-serde = ["serde", "serde_json"]
-curl-client = ["surf/curl-client"]
-h1-client = ["surf/h1-client"]
-h1-client-rustls = ["surf/h1-client-rustls"]
-hyper-client = ["surf/hyper-client"]
-wasm-client = ["surf/wasm-client"]
-default = ["use-serde", "hyper-client"]
+default = ["use-serde", "reqwest-client-rustls"]
 derive = ["influxdb_derive"]
+use-serde = ["serde", "serde_json"]
+
+# http clients
+curl-client = ["surf", "surf/curl-client"]
+h1-client = ["surf", "surf/h1-client"]
+h1-client-rustls = ["surf", "surf/h1-client-rustls"]
+hyper-client = ["surf", "surf/hyper-client"]
+reqwest-client = ["reqwest", "reqwest/native-tls-alpn"]
+reqwest-client-rustls = ["reqwest", "reqwest/rustls-tls-webpki-roots"]
+wasm-client = ["surf", "surf/wasm-client"]
 
 [dev-dependencies]
 async-std = { version = "1.6.5", features = ["attributes"] }
-tokio = { version =  "0.2.22", features = ["rt-threaded", "macros"] }
+tokio02 = { package = "tokio", version = "0.2.22", features = ["rt-threaded", "macros"] }
+tokio = { version = "1.7", features = ["rt"] }

--- a/influxdb/Cargo.toml
+++ b/influxdb/Cargo.toml
@@ -45,4 +45,4 @@ wasm-client = ["surf", "surf/wasm-client"]
 [dev-dependencies]
 async-std = { version = "1.6.5", features = ["attributes"] }
 tokio02 = { package = "tokio", version = "0.2.22", features = ["rt-threaded", "macros"] }
-tokio = { version = "1.7", features = ["macros", "rt"] }
+tokio = { version = "1.7", features = ["macros", "rt-multi-thread"] }

--- a/influxdb/src/integrations/serde_integration/mod.rs
+++ b/influxdb/src/integrations/serde_integration/mod.rs
@@ -48,11 +48,9 @@
 
 mod de;
 
-use surf::StatusCode;
-
 use serde::{de::DeserializeOwned, Deserialize};
 
-use crate::{Client, Error, Query, ReadQuery};
+use crate::{Client, Error, Query, ReadQuery, client::check_status};
 
 #[derive(Deserialize)]
 #[doc(hidden)]
@@ -143,30 +141,31 @@ impl Client {
         let url = &format!("{}/query", &self.url);
         let mut parameters = self.parameters.as_ref().clone();
         parameters.insert("q", read_query);
-        let request = self
+        let request_builder = self
             .client
             .get(url)
-            .query(&parameters)
-            .map_err(|err| Error::UrlConstructionError {
-                error: err.to_string(),
-            })?
-            .build();
+            .query(&parameters);
 
-        let mut res = self
-            .client
-            .send(request)
+        #[cfg(feature = "surf")]
+        let request_builder = request_builder.map_err(|err| Error::UrlConstructionError {
+            error: err.to_string(),
+        })?;
+
+        let res = request_builder.send()
             .await
             .map_err(|err| Error::ConnectionError {
                 error: err.to_string(),
             })?;
+        check_status(&res)?;
 
-        match res.status() {
-            StatusCode::Unauthorized => return Err(Error::AuthorizationError),
-            StatusCode::Forbidden => return Err(Error::AuthenticationError),
-            _ => {}
-        }
-
-        let body = res.body_bytes().await.map_err(|err| Error::ProtocolError {
+        #[cfg(feature = "reqwest")]
+        let body = res.bytes();
+        #[cfg(feature = "surf")]
+        let mut res = res;
+        #[cfg(feature = "surf")]
+        let body = res.body_bytes();
+        
+        let body = body.await.map_err(|err| Error::ProtocolError {
             error: err.to_string(),
         })?;
 

--- a/influxdb/src/integrations/serde_integration/mod.rs
+++ b/influxdb/src/integrations/serde_integration/mod.rs
@@ -50,7 +50,7 @@ mod de;
 
 use serde::{de::DeserializeOwned, Deserialize};
 
-use crate::{Client, Error, Query, ReadQuery, client::check_status};
+use crate::{client::check_status, Client, Error, Query, ReadQuery};
 
 #[derive(Deserialize)]
 #[doc(hidden)]
@@ -141,17 +141,15 @@ impl Client {
         let url = &format!("{}/query", &self.url);
         let mut parameters = self.parameters.as_ref().clone();
         parameters.insert("q", read_query);
-        let request_builder = self
-            .client
-            .get(url)
-            .query(&parameters);
+        let request_builder = self.client.get(url).query(&parameters);
 
         #[cfg(feature = "surf")]
         let request_builder = request_builder.map_err(|err| Error::UrlConstructionError {
             error: err.to_string(),
         })?;
 
-        let res = request_builder.send()
+        let res = request_builder
+            .send()
             .await
             .map_err(|err| Error::ConnectionError {
                 error: err.to_string(),
@@ -164,7 +162,7 @@ impl Client {
         let mut res = res;
         #[cfg(feature = "surf")]
         let body = res.body_bytes();
-        
+
         let body = body.await.map_err(|err| Error::ProtocolError {
             error: err.to_string(),
         })?;

--- a/influxdb/tests/derive_integration_tests.rs
+++ b/influxdb/tests/derive_integration_tests.rs
@@ -51,8 +51,7 @@ fn test_build_query() {
 /// INTEGRATION TEST
 ///
 /// This integration tests that writing data and retrieving the data again is working
-#[cfg_attr(feature = "surf", tokio02::test)]
-#[cfg_attr(feature = "reqwest", tokio::test)]
+#[async_std::test]
 #[cfg(not(tarpaulin_include))]
 async fn test_derive_simple_write() {
     const TEST_NAME: &str = "test_derive_simple_write";
@@ -83,8 +82,7 @@ async fn test_derive_simple_write() {
 /// This integration tests that writing data and retrieving the data again is working
 #[cfg(feature = "derive")]
 #[cfg(feature = "use-serde")]
-#[cfg_attr(feature = "surf", tokio02::test)]
-#[cfg_attr(feature = "reqwest", tokio::test)]
+#[async_std::test]
 #[cfg(not(tarpaulin_include))]
 async fn test_write_and_read_option() {
     const TEST_NAME: &str = "test_write_and_read_option";

--- a/influxdb/tests/derive_integration_tests.rs
+++ b/influxdb/tests/derive_integration_tests.rs
@@ -51,7 +51,8 @@ fn test_build_query() {
 /// INTEGRATION TEST
 ///
 /// This integration tests that writing data and retrieving the data again is working
-#[async_std::test]
+#[cfg_attr(feature = "surf", tokio02::test)]
+#[cfg_attr(feature = "reqwest", tokio::test)]
 #[cfg(not(tarpaulin_include))]
 async fn test_derive_simple_write() {
     const TEST_NAME: &str = "test_derive_simple_write";
@@ -82,7 +83,8 @@ async fn test_derive_simple_write() {
 /// This integration tests that writing data and retrieving the data again is working
 #[cfg(feature = "derive")]
 #[cfg(feature = "use-serde")]
-#[async_std::test]
+#[cfg_attr(feature = "surf", tokio02::test)]
+#[cfg_attr(feature = "reqwest", tokio::test)]
 #[cfg(not(tarpaulin_include))]
 async fn test_write_and_read_option() {
     const TEST_NAME: &str = "test_write_and_read_option";

--- a/influxdb/tests/integration_tests.rs
+++ b/influxdb/tests/integration_tests.rs
@@ -13,7 +13,7 @@ use influxdb::{Client, Error, Query, Timestamp};
 ///
 /// This test case tests whether the InfluxDB server can be connected to and gathers info about it - tested with async_std
 #[async_std::test]
-#[cfg(not(tarpaulin_include))]
+#[cfg(not(any(tarpaulin_include, feature = "reqwest")))]
 async fn test_ping_influx_db_async_std() {
     let client = create_client("notusedhere");
     let result = client.ping().await;
@@ -29,7 +29,8 @@ async fn test_ping_influx_db_async_std() {
 /// INTEGRATION TEST
 ///
 /// This test case tests whether the InfluxDB server can be connected to and gathers info about it * tested with tokio
-#[tokio::test]
+#[cfg_attr(feature = "surf", tokio02::test)]
+#[cfg_attr(feature = "reqwest", tokio::test)]
 #[cfg(not(tarpaulin_include))]
 async fn test_ping_influx_db_tokio() {
     let client = create_client("notusedhere");
@@ -46,7 +47,8 @@ async fn test_ping_influx_db_tokio() {
 /// INTEGRATION TEST
 ///
 /// This test case tests connection error
-#[async_std::test]
+#[cfg_attr(feature = "surf", tokio02::test)]
+#[cfg_attr(feature = "reqwest", tokio::test)]
 #[cfg(not(tarpaulin_include))]
 async fn test_connection_error() {
     let test_name = "test_connection_error";
@@ -67,7 +69,8 @@ async fn test_connection_error() {
 /// INTEGRATION TEST
 ///
 /// This test case tests the Authentication
-#[async_std::test]
+#[cfg_attr(feature = "surf", tokio02::test)]
+#[cfg_attr(feature = "reqwest", tokio::test)]
 #[cfg(not(tarpaulin_include))]
 async fn test_authed_write_and_read() {
     const TEST_NAME: &str = "test_authed_write_and_read";
@@ -115,7 +118,8 @@ async fn test_authed_write_and_read() {
 /// INTEGRATION TEST
 ///
 /// This test case tests the Authentication
-#[async_std::test]
+#[cfg_attr(feature = "surf", tokio02::test)]
+#[cfg_attr(feature = "reqwest", tokio::test)]
 #[cfg(not(tarpaulin_include))]
 async fn test_wrong_authed_write_and_read() {
     const TEST_NAME: &str = "test_wrong_authed_write_and_read";
@@ -185,7 +189,8 @@ async fn test_wrong_authed_write_and_read() {
 /// INTEGRATION TEST
 ///
 /// This test case tests the Authentication
-#[async_std::test]
+#[cfg_attr(feature = "surf", tokio02::test)]
+#[cfg_attr(feature = "reqwest", tokio::test)]
 #[cfg(not(tarpaulin_include))]
 async fn test_non_authed_write_and_read() {
     const TEST_NAME: &str = "test_non_authed_write_and_read";
@@ -240,7 +245,8 @@ async fn test_non_authed_write_and_read() {
 /// INTEGRATION TEST
 ///
 /// This integration tests that writing data and retrieving the data again is working
-#[async_std::test]
+#[cfg_attr(feature = "surf", tokio02::test)]
+#[cfg_attr(feature = "reqwest", tokio::test)]
 #[cfg(not(tarpaulin_include))]
 async fn test_write_and_read_field() {
     const TEST_NAME: &str = "test_write_field";
@@ -273,7 +279,8 @@ async fn test_write_and_read_field() {
 /// INTEGRATION TEST
 ///
 /// This integration tests that writing data and retrieving the data again is working
-#[async_std::test]
+#[cfg_attr(feature = "surf", tokio02::test)]
+#[cfg_attr(feature = "reqwest", tokio::test)]
 #[cfg(feature = "use-serde")]
 #[cfg(not(tarpaulin_include))]
 async fn test_write_and_read_option() {
@@ -335,7 +342,8 @@ async fn test_write_and_read_option() {
 ///
 /// This test case tests whether JSON can be decoded from a InfluxDB response and whether that JSON
 /// is equal to the data which was written to the database
-#[async_std::test]
+#[cfg_attr(feature = "surf", tokio02::test)]
+#[cfg_attr(feature = "reqwest", tokio::test)]
 #[cfg(feature = "use-serde")]
 #[cfg(not(tarpaulin_include))]
 async fn test_json_query() {
@@ -386,8 +394,9 @@ async fn test_json_query() {
 /// INTEGRATION TEST
 ///
 /// This test case tests whether the response to a GROUP BY can be parsed by
-// deserialize_next_tagged into a tags struct
-#[async_std::test]
+/// deserialize_next_tagged into a tags struct
+#[cfg_attr(feature = "surf", tokio02::test)]
+#[cfg_attr(feature = "reqwest", tokio::test)]
 #[cfg(feature = "use-serde")]
 #[cfg(not(tarpaulin_include))]
 async fn test_json_query_tagged() {
@@ -451,8 +460,8 @@ async fn test_json_query_tagged() {
 ///
 /// This test case tests whether JSON can be decoded from a InfluxDB response and wether that JSON
 /// is equal to the data which was written to the database
-/// (tested with tokio)
-#[tokio::test]
+#[cfg_attr(feature = "surf", tokio02::test)]
+#[cfg_attr(feature = "reqwest", tokio::test)]
 #[cfg(feature = "use-serde")]
 #[cfg(not(tarpaulin_include))]
 async fn test_json_query_vec() {
@@ -503,7 +512,8 @@ async fn test_json_query_vec() {
 /// INTEGRATION TEST
 ///
 /// This integration test tests whether using the wrong query method fails building the query
-#[async_std::test]
+#[cfg_attr(feature = "surf", tokio02::test)]
+#[cfg_attr(feature = "reqwest", tokio::test)]
 #[cfg(feature = "use-serde")]
 #[cfg(not(tarpaulin_include))]
 async fn test_serde_multi_query() {
@@ -580,7 +590,8 @@ async fn test_serde_multi_query() {
 /// INTEGRATION TEST
 ///
 /// This integration test tests whether using the wrong query method fails building the query
-#[async_std::test]
+#[cfg_attr(feature = "surf", tokio02::test)]
+#[cfg_attr(feature = "reqwest", tokio::test)]
 #[cfg(feature = "use-serde")]
 #[cfg(not(tarpaulin_include))]
 async fn test_wrong_query_errors() {

--- a/influxdb/tests/integration_tests.rs
+++ b/influxdb/tests/integration_tests.rs
@@ -13,7 +13,7 @@ use influxdb::{Client, Error, Query, Timestamp};
 ///
 /// This test case tests whether the InfluxDB server can be connected to and gathers info about it - tested with async_std
 #[async_std::test]
-#[cfg(not(any(tarpaulin_include, feature = "reqwest")))]
+#[cfg(not(tarpaulin_include))]
 async fn test_ping_influx_db_async_std() {
     let client = create_client("notusedhere");
     let result = client.ping().await;
@@ -29,8 +29,7 @@ async fn test_ping_influx_db_async_std() {
 /// INTEGRATION TEST
 ///
 /// This test case tests whether the InfluxDB server can be connected to and gathers info about it * tested with tokio
-#[cfg_attr(feature = "surf", tokio02::test)]
-#[cfg_attr(feature = "reqwest", tokio::test)]
+#[tokio::test]
 #[cfg(not(tarpaulin_include))]
 async fn test_ping_influx_db_tokio() {
     let client = create_client("notusedhere");
@@ -47,8 +46,7 @@ async fn test_ping_influx_db_tokio() {
 /// INTEGRATION TEST
 ///
 /// This test case tests connection error
-#[cfg_attr(feature = "surf", tokio02::test)]
-#[cfg_attr(feature = "reqwest", tokio::test)]
+#[async_std::test]
 #[cfg(not(tarpaulin_include))]
 async fn test_connection_error() {
     let test_name = "test_connection_error";
@@ -69,8 +67,7 @@ async fn test_connection_error() {
 /// INTEGRATION TEST
 ///
 /// This test case tests the Authentication
-#[cfg_attr(feature = "surf", tokio02::test)]
-#[cfg_attr(feature = "reqwest", tokio::test)]
+#[async_std::test]
 #[cfg(not(tarpaulin_include))]
 async fn test_authed_write_and_read() {
     const TEST_NAME: &str = "test_authed_write_and_read";
@@ -118,8 +115,7 @@ async fn test_authed_write_and_read() {
 /// INTEGRATION TEST
 ///
 /// This test case tests the Authentication
-#[cfg_attr(feature = "surf", tokio02::test)]
-#[cfg_attr(feature = "reqwest", tokio::test)]
+#[async_std::test]
 #[cfg(not(tarpaulin_include))]
 async fn test_wrong_authed_write_and_read() {
     const TEST_NAME: &str = "test_wrong_authed_write_and_read";
@@ -189,8 +185,7 @@ async fn test_wrong_authed_write_and_read() {
 /// INTEGRATION TEST
 ///
 /// This test case tests the Authentication
-#[cfg_attr(feature = "surf", tokio02::test)]
-#[cfg_attr(feature = "reqwest", tokio::test)]
+#[async_std::test]
 #[cfg(not(tarpaulin_include))]
 async fn test_non_authed_write_and_read() {
     const TEST_NAME: &str = "test_non_authed_write_and_read";
@@ -245,8 +240,7 @@ async fn test_non_authed_write_and_read() {
 /// INTEGRATION TEST
 ///
 /// This integration tests that writing data and retrieving the data again is working
-#[cfg_attr(feature = "surf", tokio02::test)]
-#[cfg_attr(feature = "reqwest", tokio::test)]
+#[async_std::test]
 #[cfg(not(tarpaulin_include))]
 async fn test_write_and_read_field() {
     const TEST_NAME: &str = "test_write_field";
@@ -279,8 +273,7 @@ async fn test_write_and_read_field() {
 /// INTEGRATION TEST
 ///
 /// This integration tests that writing data and retrieving the data again is working
-#[cfg_attr(feature = "surf", tokio02::test)]
-#[cfg_attr(feature = "reqwest", tokio::test)]
+#[async_std::test]
 #[cfg(feature = "use-serde")]
 #[cfg(not(tarpaulin_include))]
 async fn test_write_and_read_option() {
@@ -342,8 +335,7 @@ async fn test_write_and_read_option() {
 ///
 /// This test case tests whether JSON can be decoded from a InfluxDB response and whether that JSON
 /// is equal to the data which was written to the database
-#[cfg_attr(feature = "surf", tokio02::test)]
-#[cfg_attr(feature = "reqwest", tokio::test)]
+#[async_std::test]
 #[cfg(feature = "use-serde")]
 #[cfg(not(tarpaulin_include))]
 async fn test_json_query() {
@@ -395,8 +387,7 @@ async fn test_json_query() {
 ///
 /// This test case tests whether the response to a GROUP BY can be parsed by
 /// deserialize_next_tagged into a tags struct
-#[cfg_attr(feature = "surf", tokio02::test)]
-#[cfg_attr(feature = "reqwest", tokio::test)]
+#[async_std::test]
 #[cfg(feature = "use-serde")]
 #[cfg(not(tarpaulin_include))]
 async fn test_json_query_tagged() {
@@ -460,8 +451,8 @@ async fn test_json_query_tagged() {
 ///
 /// This test case tests whether JSON can be decoded from a InfluxDB response and wether that JSON
 /// is equal to the data which was written to the database
-#[cfg_attr(feature = "surf", tokio02::test)]
-#[cfg_attr(feature = "reqwest", tokio::test)]
+/// (tested with tokio)
+#[tokio::test]
 #[cfg(feature = "use-serde")]
 #[cfg(not(tarpaulin_include))]
 async fn test_json_query_vec() {
@@ -512,8 +503,7 @@ async fn test_json_query_vec() {
 /// INTEGRATION TEST
 ///
 /// This integration test tests whether using the wrong query method fails building the query
-#[cfg_attr(feature = "surf", tokio02::test)]
-#[cfg_attr(feature = "reqwest", tokio::test)]
+#[async_std::test]
 #[cfg(feature = "use-serde")]
 #[cfg(not(tarpaulin_include))]
 async fn test_serde_multi_query() {
@@ -590,8 +580,7 @@ async fn test_serde_multi_query() {
 /// INTEGRATION TEST
 ///
 /// This integration test tests whether using the wrong query method fails building the query
-#[cfg_attr(feature = "surf", tokio02::test)]
-#[cfg_attr(feature = "reqwest", tokio::test)]
+#[async_std::test]
 #[cfg(feature = "use-serde")]
 #[cfg(not(tarpaulin_include))]
 async fn test_wrong_query_errors() {

--- a/influxdb/tests/integration_tests.rs
+++ b/influxdb/tests/integration_tests.rs
@@ -28,9 +28,9 @@ async fn test_ping_influx_db_async_std() {
 
 /// INTEGRATION TEST
 ///
-/// This test case tests whether the InfluxDB server can be connected to and gathers info about it * tested with tokio
+/// This test case tests whether the InfluxDB server can be connected to and gathers info about it - tested with tokio 1.0
 #[tokio::test]
-#[cfg(not(tarpaulin_include))]
+#[cfg(not(any(tarpaulin_include, feature = "hyper-client")))]
 async fn test_ping_influx_db_tokio() {
     let client = create_client("notusedhere");
     let result = client.ping().await;

--- a/influxdb/tests/integration_tests.rs
+++ b/influxdb/tests/integration_tests.rs
@@ -453,8 +453,10 @@ async fn test_json_query_tagged() {
 /// is equal to the data which was written to the database
 /// (tested with tokio)
 #[tokio::test]
-#[cfg(feature = "use-serde")]
-#[cfg(not(tarpaulin_include))]
+#[cfg(all(
+    feature = "use-serde",
+    not(any(tarpaulin_include, feature = "hyper-client"))
+))]
 async fn test_json_query_vec() {
     use serde::Deserialize;
 


### PR DESCRIPTION
Fixes #82 
Fixes #90 

## Description

Using reqwest over surf has a few advantages:

 - it has already update to tokio 1.0, which has been out there for 6 month now
 - it's less of a dependency hell than surf

However, I've kept the existing surf-based feature flags for those that really need async-std compatibily.

Some notes:

 - I've bumped the MSRV from 1.45 to 1.46 so that the `socket2` dependency compiles
 - I've made it a hard error if both surf and reqwest features are enabled. We could prioritize one over the other, however, that would make the `#[cfg]` statements more complex. Also, there are other error messages than my custom ones, which could be suppressed but would add more complexity.

### Checklist
- [x] Formatted code using `cargo fmt --all`
- [x] Linted code using clippy `cargo clippy --all-targets --all-features -- -D warnings` - **I didn't introduce those warnings**
- [x] Updated README.md using `cargo readme -r influxdb -t ../README.tpl > README.md`
- [x] Reviewed the diff. Did you leave any print statements or unnecessary comments?
- [x] Any unfinished work that warrants a separate issue captured in an issue with a TODO code comment