### PR TITLE
Replace Surf with Reqwest to allow for upgrading Tokio to 1.x.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,9 +48,6 @@ jobs:
     integration_test:
         name: Integration Tests (stable/ubuntu-latest)
         runs-on: ubuntu-latest
-        strategy:
-            matrix:
-                http-backend: [curl-client, h1-client, h1-client-rustls, hyper-client]
         services:
             influxdb:
                 image: influxdb:1.8
@@ -70,7 +67,7 @@ jobs:
         steps:
             - uses: actions/checkout@v1
             - uses: dtolnay/rust-toolchain@stable
-            - run: cargo test --manifest-path=./influxdb/Cargo.toml --no-default-features --features 'use-serde derive ${{ matrix.http-backend }}' --no-fail-fast
+            - run: cargo test --manifest-path=./influxdb/Cargo.toml --all --all-features --no-fail-fast
 
     coverage:
         name: Code Coverage (stable/ubuntu-20.04)

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ async fn main() {
     assert!(write_result.is_ok(), "Write result was not okay");
 
     // Let's see if the data we wrote is there
-    let read_query = Query::raw_read_query("SELECT * FROM weather");
+    let read_query = <dyn Query>::raw_read_query("SELECT * FROM weather");
 
     let read_result = client.query(&read_query).await;
     assert!(read_result.is_ok(), "Read result was not ok");

--- a/benches/client.rs
+++ b/benches/client.rs
@@ -67,7 +67,7 @@ async fn main() {
 async fn prepare_influxdb(client: &Client, db_name: &str) {
     let create_db_stmt = format!("CREATE DATABASE {}", db_name);
     client
-        .query(&Query::raw_read_query(create_db_stmt))
+        .query(&<dyn Query>::raw_read_query(create_db_stmt))
         .await
         .expect("failed to create database");
 }

--- a/influxdb/Cargo.toml
+++ b/influxdb/Cargo.toml
@@ -21,21 +21,16 @@ futures = "0.3.4"
 lazy_static = "1.4.0"
 influxdb_derive = { version = "0.4.0", optional = true }
 regex = "1.3.5"
-surf = { version = "2.2.0", default-features = false }
+reqwest = { version = "0.11" }
 serde = { version = "1.0.104", features = ["derive"], optional = true }
 serde_json = { version = "1.0.48", optional = true }
 thiserror = "1.0"
 
 [features]
 use-serde = ["serde", "serde_json"]
-curl-client = ["surf/curl-client"]
-h1-client = ["surf/h1-client"]
-h1-client-rustls = ["surf/h1-client-rustls"]
-hyper-client = ["surf/hyper-client"]
-wasm-client = ["surf/wasm-client"]
-default = ["use-serde", "hyper-client"]
+default = ["use-serde"]
 derive = ["influxdb_derive"]
 
 [dev-dependencies]
 async-std = { version = "1.6.5", features = ["attributes"] }
-tokio = { version =  "0.2.22", features = ["rt-threaded", "macros"] }
+tokio = { version =  "1.8.1", features = ["macros", "test-util"] }

--- a/influxdb/src/lib.rs
+++ b/influxdb/src/lib.rs
@@ -56,7 +56,7 @@
 //!     assert!(write_result.is_ok(), "Write result was not okay");
 //!
 //!     // Let's see if the data we wrote is there
-//!     let read_query = Query::raw_read_query("SELECT * FROM weather");
+//!     let read_query = <dyn Query>::raw_read_query("SELECT * FROM weather");
 //!
 //!     let read_result = client.query(&read_query).await;
 //!     assert!(read_result.is_ok(), "Read result was not ok");

--- a/influxdb/src/query/mod.rs
+++ b/influxdb/src/query/mod.rs
@@ -14,7 +14,7 @@
 //!
 //! assert!(write_query.is_ok());
 //!
-//! let read_query = Query::raw_read_query("SELECT * FROM weather")
+//! let read_query = <dyn Query>::raw_read_query("SELECT * FROM weather")
 //!     .build();
 //!
 //! assert!(read_query.is_ok());
@@ -133,7 +133,7 @@ impl dyn Query {
     /// ```rust
     /// use influxdb::Query;
     ///
-    /// Query::raw_read_query("SELECT * FROM weather"); // Is of type [`ReadQuery`](crate::ReadQuery)
+    /// <dyn Query>::raw_read_query("SELECT * FROM weather"); // Is of type [`ReadQuery`](crate::ReadQuery)
     /// ```
     pub fn raw_read_query<S>(read_query: S) -> ReadQuery
     where

--- a/influxdb/src/query/read_query.rs
+++ b/influxdb/src/query/read_query.rs
@@ -1,6 +1,6 @@
-//! Read Query Builder returned by Query::raw_read_query
+//! Read Query Builder returned by <dyn Query>::raw_read_query
 //!
-//! Can only be instantiated by using Query::raw_read_query
+//! Can only be instantiated by using <dyn Query>::raw_read_query
 
 use crate::query::{QueryType, ValidQuery};
 use crate::{Error, Query};
@@ -47,14 +47,14 @@ mod tests {
 
     #[test]
     fn test_read_builder_single_query() {
-        let query = Query::raw_read_query("SELECT * FROM aachen").build();
+        let query = <dyn Query>::raw_read_query("SELECT * FROM aachen").build();
 
         assert_eq!(query.unwrap(), "SELECT * FROM aachen");
     }
 
     #[test]
     fn test_read_builder_multi_query() {
-        let query = Query::raw_read_query("SELECT * FROM aachen")
+        let query = <dyn Query>::raw_read_query("SELECT * FROM aachen")
             .add_query("SELECT * FROM cologne")
             .build();
 
@@ -63,7 +63,7 @@ mod tests {
 
     #[test]
     fn test_correct_query_type() {
-        let query = Query::raw_read_query("SELECT * FROM aachen");
+        let query = <dyn Query>::raw_read_query("SELECT * FROM aachen");
 
         assert_eq!(query.get_type(), QueryType::ReadQuery);
     }

--- a/influxdb/tests/derive_integration_tests.rs
+++ b/influxdb/tests/derive_integration_tests.rs
@@ -51,7 +51,7 @@ fn test_build_query() {
 /// INTEGRATION TEST
 ///
 /// This integration tests that writing data and retrieving the data again is working
-#[async_std::test]
+#[tokio::test]
 #[cfg(not(tarpaulin_include))]
 async fn test_derive_simple_write() {
     const TEST_NAME: &str = "test_derive_simple_write";
@@ -82,7 +82,7 @@ async fn test_derive_simple_write() {
 /// This integration tests that writing data and retrieving the data again is working
 #[cfg(feature = "derive")]
 #[cfg(feature = "use-serde")]
-#[async_std::test]
+#[tokio::test]
 #[cfg(not(tarpaulin_include))]
 async fn test_write_and_read_option() {
     const TEST_NAME: &str = "test_write_and_read_option";
@@ -102,7 +102,7 @@ async fn test_write_and_read_option() {
                 .await;
             assert_result_ok(&write_result);
             let query =
-                Query::raw_read_query("SELECT time, pressure, wind_strength FROM weather_reading");
+                <dyn Query>::raw_read_query("SELECT time, pressure, wind_strength FROM weather_reading");
             let result = client.json_query(query).await.and_then(|mut db_result| {
                 println!("{:?}", db_result);
                 db_result.deserialize_next::<WeatherReadingWithoutIgnored>()

--- a/influxdb/tests/integration_tests.rs
+++ b/influxdb/tests/integration_tests.rs
@@ -12,7 +12,7 @@ use influxdb::{Client, Error, Query, Timestamp};
 /// INTEGRATION TEST
 ///
 /// This test case tests whether the InfluxDB server can be connected to and gathers info about it - tested with async_std
-#[async_std::test]
+#[tokio::test]
 #[cfg(not(tarpaulin_include))]
 async fn test_ping_influx_db_async_std() {
     let client = create_client("notusedhere");
@@ -46,13 +46,13 @@ async fn test_ping_influx_db_tokio() {
 /// INTEGRATION TEST
 ///
 /// This test case tests connection error
-#[async_std::test]
+#[tokio::test]
 #[cfg(not(tarpaulin_include))]
 async fn test_connection_error() {
     let test_name = "test_connection_error";
     let client =
         Client::new("http://127.0.0.1:10086", test_name).with_auth("nopriv_user", "password");
-    let read_query = Query::raw_read_query("SELECT * FROM weather");
+    let read_query = <dyn Query>::raw_read_query("SELECT * FROM weather");
     let read_result = client.query(&read_query).await;
     assert_result_err(&read_result);
     match read_result {
@@ -67,7 +67,7 @@ async fn test_connection_error() {
 /// INTEGRATION TEST
 ///
 /// This test case tests the Authentication
-#[async_std::test]
+#[tokio::test]
 #[cfg(not(tarpaulin_include))]
 async fn test_authed_write_and_read() {
     const TEST_NAME: &str = "test_authed_write_and_read";
@@ -78,7 +78,7 @@ async fn test_authed_write_and_read() {
                 Client::new("http://127.0.0.1:9086", TEST_NAME).with_auth("admin", "password");
             let query = format!("CREATE DATABASE {}", TEST_NAME);
             client
-                .query(&Query::raw_read_query(query))
+                .query(&<dyn Query>::raw_read_query(query))
                 .await
                 .expect("could not setup db");
 
@@ -90,7 +90,7 @@ async fn test_authed_write_and_read() {
             let write_result = client.query(&write_query).await;
             assert_result_ok(&write_result);
 
-            let read_query = Query::raw_read_query("SELECT * FROM weather");
+            let read_query = <dyn Query>::raw_read_query("SELECT * FROM weather");
             let read_result = client.query(&read_query).await;
             assert_result_ok(&read_result);
             assert!(
@@ -104,7 +104,7 @@ async fn test_authed_write_and_read() {
             let query = format!("DROP DATABASE {}", TEST_NAME);
 
             client
-                .query(&Query::raw_read_query(query))
+                .query(&<dyn Query>::raw_read_query(query))
                 .await
                 .expect("could not clean up db");
         },
@@ -115,7 +115,7 @@ async fn test_authed_write_and_read() {
 /// INTEGRATION TEST
 ///
 /// This test case tests the Authentication
-#[async_std::test]
+#[tokio::test]
 #[cfg(not(tarpaulin_include))]
 async fn test_wrong_authed_write_and_read() {
     const TEST_NAME: &str = "test_wrong_authed_write_and_read";
@@ -126,7 +126,7 @@ async fn test_wrong_authed_write_and_read() {
                 Client::new("http://127.0.0.1:9086", TEST_NAME).with_auth("admin", "password");
             let query = format!("CREATE DATABASE {}", TEST_NAME);
             client
-                .query(&Query::raw_read_query(query))
+                .query(&<dyn Query>::raw_read_query(query))
                 .await
                 .expect("could not setup db");
 
@@ -145,7 +145,7 @@ async fn test_wrong_authed_write_and_read() {
                 ),
             }
 
-            let read_query = Query::raw_read_query("SELECT * FROM weather");
+            let read_query = <dyn Query>::raw_read_query("SELECT * FROM weather");
             let read_result = client.query(&read_query).await;
             assert_result_err(&read_result);
             match read_result {
@@ -158,7 +158,7 @@ async fn test_wrong_authed_write_and_read() {
 
             let client = Client::new("http://127.0.0.1:9086", TEST_NAME)
                 .with_auth("nopriv_user", "password");
-            let read_query = Query::raw_read_query("SELECT * FROM weather");
+            let read_query = <dyn Query>::raw_read_query("SELECT * FROM weather");
             let read_result = client.query(&read_query).await;
             assert_result_err(&read_result);
             match read_result {
@@ -174,7 +174,7 @@ async fn test_wrong_authed_write_and_read() {
                 Client::new("http://127.0.0.1:9086", TEST_NAME).with_auth("admin", "password");
             let query = format!("DROP DATABASE {}", TEST_NAME);
             client
-                .query(&Query::raw_read_query(query))
+                .query(&<dyn Query>::raw_read_query(query))
                 .await
                 .expect("could not clean up db");
         },
@@ -185,7 +185,7 @@ async fn test_wrong_authed_write_and_read() {
 /// INTEGRATION TEST
 ///
 /// This test case tests the Authentication
-#[async_std::test]
+#[tokio::test]
 #[cfg(not(tarpaulin_include))]
 async fn test_non_authed_write_and_read() {
     const TEST_NAME: &str = "test_non_authed_write_and_read";
@@ -196,7 +196,7 @@ async fn test_non_authed_write_and_read() {
                 Client::new("http://127.0.0.1:9086", TEST_NAME).with_auth("admin", "password");
             let query = format!("CREATE DATABASE {}", TEST_NAME);
             client
-                .query(&Query::raw_read_query(query))
+                .query(&<dyn Query>::raw_read_query(query))
                 .await
                 .expect("could not setup db");
             let non_authed_client = Client::new("http://127.0.0.1:9086", TEST_NAME);
@@ -213,7 +213,7 @@ async fn test_non_authed_write_and_read() {
                 ),
             }
 
-            let read_query = Query::raw_read_query("SELECT * FROM weather");
+            let read_query = <dyn Query>::raw_read_query("SELECT * FROM weather");
             let read_result = non_authed_client.query(&read_query).await;
             assert_result_err(&read_result);
             match read_result {
@@ -229,7 +229,7 @@ async fn test_non_authed_write_and_read() {
                 Client::new("http://127.0.0.1:9086", TEST_NAME).with_auth("admin", "password");
             let query = format!("DROP DATABASE {}", TEST_NAME);
             client
-                .query(&Query::raw_read_query(query))
+                .query(&<dyn Query>::raw_read_query(query))
                 .await
                 .expect("could not clean up db");
         },
@@ -240,7 +240,7 @@ async fn test_non_authed_write_and_read() {
 /// INTEGRATION TEST
 ///
 /// This integration tests that writing data and retrieving the data again is working
-#[async_std::test]
+#[tokio::test]
 #[cfg(not(tarpaulin_include))]
 async fn test_write_and_read_field() {
     const TEST_NAME: &str = "test_write_field";
@@ -255,7 +255,7 @@ async fn test_write_and_read_field() {
             let write_result = client.query(&write_query).await;
             assert_result_ok(&write_result);
 
-            let read_query = Query::raw_read_query("SELECT * FROM weather");
+            let read_query = <dyn Query>::raw_read_query("SELECT * FROM weather");
             let read_result = client.query(&read_query).await;
             assert_result_ok(&read_result);
             assert!(
@@ -273,7 +273,7 @@ async fn test_write_and_read_field() {
 /// INTEGRATION TEST
 ///
 /// This integration tests that writing data and retrieving the data again is working
-#[async_std::test]
+#[tokio::test]
 #[cfg(feature = "use-serde")]
 #[cfg(not(tarpaulin_include))]
 async fn test_write_and_read_option() {
@@ -305,7 +305,7 @@ async fn test_write_and_read_option() {
                 }
 
                 let query =
-                    Query::raw_read_query("SELECT time, temperature, wind_strength FROM weather");
+                    <dyn Query>::raw_read_query("SELECT time, temperature, wind_strength FROM weather");
                 let result = client
                     .json_query(query)
                     .await
@@ -335,7 +335,7 @@ async fn test_write_and_read_option() {
 ///
 /// This test case tests whether JSON can be decoded from a InfluxDB response and whether that JSON
 /// is equal to the data which was written to the database
-#[async_std::test]
+#[tokio::test]
 #[cfg(feature = "use-serde")]
 #[cfg(not(tarpaulin_include))]
 async fn test_json_query() {
@@ -361,7 +361,7 @@ async fn test_json_query() {
                 temperature: i32,
             }
 
-            let query = Query::raw_read_query("SELECT * FROM weather");
+            let query = <dyn Query>::raw_read_query("SELECT * FROM weather");
             let result = client
                 .json_query(query)
                 .await
@@ -387,7 +387,7 @@ async fn test_json_query() {
 ///
 /// This test case tests whether the response to a GROUP BY can be parsed by
 // deserialize_next_tagged into a tags struct
-#[async_std::test]
+#[tokio::test]
 #[cfg(feature = "use-serde")]
 #[cfg(not(tarpaulin_include))]
 async fn test_json_query_tagged() {
@@ -419,7 +419,7 @@ async fn test_json_query_tagged() {
                 temperature: i32,
             }
 
-            let query = Query::raw_read_query("SELECT * FROM weather GROUP BY location");
+            let query = <dyn Query>::raw_read_query("SELECT * FROM weather GROUP BY location");
             let result = client.json_query(query).await.and_then(|mut db_result| {
                 db_result.deserialize_next_tagged::<WeatherMeta, Weather>()
             });
@@ -485,7 +485,7 @@ async fn test_json_query_vec() {
                 temperature: i32,
             }
 
-            let query = Query::raw_read_query("SELECT * FROM temperature_vec");
+            let query = <dyn Query>::raw_read_query("SELECT * FROM temperature_vec");
             let result = client
                 .json_query(query)
                 .await
@@ -503,7 +503,7 @@ async fn test_json_query_vec() {
 /// INTEGRATION TEST
 ///
 /// This integration test tests whether using the wrong query method fails building the query
-#[async_std::test]
+#[tokio::test]
 #[cfg(feature = "use-serde")]
 #[cfg(not(tarpaulin_include))]
 async fn test_serde_multi_query() {
@@ -542,7 +542,7 @@ async fn test_serde_multi_query() {
 
             let result = client
                 .json_query(
-                    Query::raw_read_query("SELECT * FROM temperature")
+                    <dyn Query>::raw_read_query("SELECT * FROM temperature")
                         .add_query("SELECT * FROM humidity"),
                 )
                 .await
@@ -580,13 +580,13 @@ async fn test_serde_multi_query() {
 /// INTEGRATION TEST
 ///
 /// This integration test tests whether using the wrong query method fails building the query
-#[async_std::test]
+#[tokio::test]
 #[cfg(feature = "use-serde")]
 #[cfg(not(tarpaulin_include))]
 async fn test_wrong_query_errors() {
     let client = create_client("test_name");
     let result = client
-        .json_query(Query::raw_read_query("CREATE DATABASE this_should_fail"))
+        .json_query(<dyn Query>::raw_read_query("CREATE DATABASE this_should_fail"))
         .await;
     assert!(
         result.is_err(),

--- a/influxdb/tests/utilities.rs
+++ b/influxdb/tests/utilities.rs
@@ -29,7 +29,7 @@ where
     let test_name = name.into();
     let query = format!("CREATE DATABASE {}", test_name);
     create_client(test_name)
-        .query(&Query::raw_read_query(query))
+        .query(&<dyn Query>::raw_read_query(query))
         .await
 }
 
@@ -41,7 +41,7 @@ where
     let test_name = name.into();
     let query = format!("DROP DATABASE {}", test_name);
     create_client(test_name)
-        .query(&Query::raw_read_query(query))
+        .query(&<dyn Query>::raw_read_query(query))
         .await
 }
 


### PR DESCRIPTION
I don't know if this is of interest to you, but I got into a dependency problem with Tokio. As I am more familiar with Reqwest and it is already on Tokio 1.x, I went the route of switching out Surf with Tokio. All of the tests pass locally and it appears to fully work for my use case. If you are interested in this PR, I'd be happy to clean up any changes you require, otherwise feel free to close it.

Thanks for the great library.